### PR TITLE
Quote filename since this can contain funny chars

### DIFF
--- a/dec.py
+++ b/dec.py
@@ -29,6 +29,7 @@
 
 import sys
 import os
+import pipes
 
 import logging
 import logging.handlers
@@ -158,8 +159,8 @@ def run_dpm(run_setting):
 
     dn = os.path.dirname(__file__)
     my_prog = os.path.join(dn, 'diri_sampler')
-    my_arg = ' -i "%s" -j %i -t %i -a %f -K %d' % \
-        (filein, j, int(j * hist_fraction), a, init_K)
+    my_arg = ' -i %s -j %i -t %i -a %f -K %d' % \
+        (pipes.quote(filein), j, int(j * hist_fraction), a, init_K)
 
     try:
         os.remove('./corrected.tmp')


### PR DESCRIPTION
I guess this should be done for any other filenames in shell commands, especially if the filenames are generated from fasta file headers like this one.  My filenames got pipe symbols in them (|) which broke things.
