### PR TITLE
Performance improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,8 +81,7 @@ AX_PTHREAD
 dnl ==================================
 dnl Set CXXFLAGS, CPPFLAGS and LDFLAGS
 dnl ==================================
-AS_IF([test "x${enable_flags_setting}" = "xyes" && test "x${enable_debug}" = "xno"],
-	[
+AS_IF([test "x${enable_flags_setting}" = "xyes" && test "x${enable_debug}" = "xno"], [
 	AC_LANG([C])
 	AX_APPEND_COMPILE_FLAGS([${cflags_test}], [CFLAGS])
 	CFLAGS=$( echo ${CFLAGS} | $SED -e 's/^ *//' -e 's/ *$//' )
@@ -96,8 +95,31 @@ AS_IF([test "x${enable_flags_setting}" = "xyes" && test "x${enable_debug}" = "xn
 
 	AX_APPEND_LINK_FLAGS([${ldflags_test}], [LDFLAGS])
 	LDFLAGS=$( echo ${LDFLAGS} | $SED -e 's/^ *//' -e 's/ *$//' )
-	]
-)
+])
+
+AC_ARG_ENABLE([popcnt],
+	AS_HELP_STRING([--disable-popcnt], [Disable using POPCNT for Hamming distances]))
+
+dnl Check for popcount intrinsics
+AS_IF([test "x$enable_popcnt" != "xno"], [
+	AC_LANG([C++])
+	AX_APPEND_COMPILE_FLAGS([-mpopcnt], [CXXFLAGS])
+
+	AC_MSG_CHECKING([whether configure can enable POPCNT for Hamming distances])
+	AC_LINK_IFELSE([
+		AC_LANG_SOURCE([[
+			#include <nmmintrin.h>
+			int main() { return _mm_popcnt_u64(0); }
+		]])
+	], [
+		dnl POPCNT works
+		AC_DEFINE([HAVE_POPCNT], [1], [Define if popcnt intrinsics are available])
+		AC_MSG_RESULT([yes])
+	], [
+		dnl POPCNT is broken
+		AC_MSG_RESULT([no])
+	])
+])
 
 
 

--- a/src/python/shorah_dec.py
+++ b/src/python/shorah_dec.py
@@ -576,7 +576,7 @@ def main(in_bam='', in_fasta='', win_length=201, win_shifts=3, region='',
 
     declog.info('running snv.py')
     shorah_snv.main(reference=in_fasta, bam_file=in_bam,
-             increment=win_length / win_shifts)
+             increment=win_length / win_shifts, max_coverage=max_coverage)
 
     # tidy snvs
     try:

--- a/src/python/shorah_snv.py
+++ b/src/python/shorah_snv.py
@@ -304,14 +304,15 @@ def printRaw(snpD2, incr):
     out1.close()
 
 
-def sb_filter(in_bam, sigma, amplimode=""):
+def sb_filter(in_bam, sigma, amplimode="", max_coverage=100000):
 
     """run strand bias filter calling the external program 'fil'
     """
     import subprocess
     dn = sys.path[0]
     my_prog = os.path.join(dn, 'fil')
-    my_arg = ' -b ' + in_bam + ' -v ' + str(sigma) + amplimode
+    my_arg = ' -b ' + in_bam + ' -v ' + str(sigma) + amplimode + ' -x ' \
+             + max_coverage
     snvlog.debug('running %s%s' % (my_prog, my_arg))
     retcode = subprocess.call(my_prog + my_arg, shell=True)
     return retcode
@@ -339,7 +340,7 @@ def BH(p_vals, n):
     return q_vals_l
 
 
-def main(reference='', bam_file='', sigma=0.01, increment=1):
+def main(reference='', bam_file='', sigma=0.01, increment=1, max_coverage=100000):
     '''main code
     '''
     import csv
@@ -376,9 +377,10 @@ def main(reference='', bam_file='', sigma=0.01, increment=1):
 
     #run strand bias filter, output in SNVs_%sigma.txt
     if increment == 1:
-        retcode_m = sb_filter(bam_file, sigma, amplimode=" -a")
+        retcode_m = sb_filter(bam_file, sigma, amplimode=" -a",
+                              max_coverage=max_coverage)
     else:
-        retcode_m = sb_filter(bam_file, sigma)
+        retcode_m = sb_filter(bam_file, sigma, max_coverage=max_coverage)
     if retcode_m is not 0:
         snvlog.error('sb_filter exited with error %d' % retcode_m)
         sys.exit()

--- a/src/python/shorah_snv.py
+++ b/src/python/shorah_snv.py
@@ -312,7 +312,7 @@ def sb_filter(in_bam, sigma, amplimode="", max_coverage=100000):
     dn = sys.path[0]
     my_prog = os.path.join(dn, 'fil')
     my_arg = ' -b ' + in_bam + ' -v ' + str(sigma) + amplimode + ' -x ' \
-             + max_coverage
+             + str(max_coverage)
     snvlog.debug('running %s%s' % (my_prog, my_arg))
     retcode = subprocess.call(my_prog + my_arg, shell=True)
     return retcode

--- a/src/scripts/dec.py.in
+++ b/src/scripts/dec.py.in
@@ -47,6 +47,10 @@ group3.add_option("-k", "--keep_files",
                   action="store_true", dest="keep_files",
                   default=opts[7])
 
+group2.add_option("-S", "--seed",
+                  help="Set seed for reproducibility",
+                  default=opts[8], type=int, dest="seed")
+
 optparser.add_option_group(group1)
 optparser.add_option_group(group2)
 optparser.add_option_group(group3)

--- a/src/scripts/snv.py.in
+++ b/src/scripts/snv.py.in
@@ -23,4 +23,10 @@ optparser.add_option("-i", "--increment", default=opts[3], type="int",
 
 (options, args) = optparser.parse_args()
 
+optparser.add_option("-x", "--maxcov", default=opts[4], type="int",
+                     dest="max_coverage", help="Maximum coverage allowed \
+                     <%default>")
+
+(options, args) = optparser.parse_args()
+
 shorah_snv.main(*args, **vars(options))

--- a/src/scripts/snv.py.in
+++ b/src/scripts/snv.py.in
@@ -21,8 +21,6 @@ optparser.add_option("-i", "--increment", default=opts[3], type="int",
                      dest="increment", help="value of increment to use \
                      when calling SNVs (1 used by amplian.py) <%default>")
 
-(options, args) = optparser.parse_args()
-
 optparser.add_option("-x", "--maxcov", default=opts[4], type="int",
                      dest="max_coverage", help="Maximum coverage allowed \
                      <%default>")

--- a/src/shorah/data_structures.hpp
+++ b/src/shorah/data_structures.hpp
@@ -169,14 +169,21 @@ typedef struct cns {
   /** *********************************************************
       Components list structure:
       c -> indexes the component
-      theta -> mutation parameter
+      size -> component size (number of unique reads)
+      weight -> weighted component size (accounting for reads represented by 
+                each unique read)
       rlist -> points to the list of reads
-      h -> haplotype
+      hh -> points to the list of haplotypes
+      h -> haplotype sequence
+      rd0 -> points to a vector storing hamming distances between h and all 
+             unique reads
+      rd1 -> points to a vector storing similarities between h and all unique
+             reads
       next -> next node
       ********************************************************** */
   unsigned int ci;
   unsigned int size;
-  //double theta,theta2;
+  unsigned int weight; 
   struct rns* rlist;
   struct hns* hh;
   unsigned short int* h;
@@ -314,14 +321,14 @@ void move_read(unsigned int i, cnode** from, cnode** to){
     while(rn->next != NULL){
       
       if(rn->next->ri == i){
-	tmp = rn->next;
-	rn->next = rn->next->next;
-
-	tmp2 = (*to)->rlist;
-	(*to)->rlist = tmp;
-	(*to)->rlist->next = tmp2;
+        tmp = rn->next;
+        rn->next = rn->next->next;
+        
+        tmp2 = (*to)->rlist;
+        (*to)->rlist = tmp;
+        (*to)->rlist->next = tmp2;
 	
-	break;
+        break;
       }
       
       rn = rn->next;

--- a/src/shorah/data_structures.hpp
+++ b/src/shorah/data_structures.hpp
@@ -168,7 +168,7 @@ hnode* add_hap(hnode** p, hnode* pred, unsigned int i, unsigned int J, unsigned 
 typedef struct cns {
   /** *********************************************************
       Components list structure:
-      c -> indexes the component
+      ci -> index of the component
       size -> component size (number of unique reads)
       weight -> weighted component size (accounting for reads represented by 
                 each unique read)

--- a/src/shorah/dpm_sampler.cpp
+++ b/src/shorah/dpm_sampler.cpp
@@ -426,7 +426,7 @@ int main(int argc, char** argv){
       sampling ends
   *********************/
   
-  stat_file << "# Survived sampling"<<endl;
+  stat_file << "# Survived sampling" << endl;
   stat_file << "# sampling took " << difftime(t2, t1) << " seconds\n";
   
   //  write_assignment(k, new_proposed, mxt);
@@ -437,11 +437,11 @@ int main(int argc, char** argv){
   for(j=0; j<J; j++)
     stat_file << i2dna_code[h[j]];
   stat_file << "\n\n\n";
-  stat_file << "\n#gamma = " << gam << "\n";
-  stat_file << "\n#theta = " << theta << "\n";
+  stat_file << "\n#gamma = " << gam << endl;
+  stat_file << "\n#theta = " << theta << endl;
   stat_file << "\n#final number of components = " << K1 << "\n";
   stat_file << "\n#made "<< new_proposed << " new clusters\n";
-  stat_file << "\n#number of haplotypes in history = " << haplotypecount << "\n";
+  stat_file << "\n#number of haplotypes in history = " << haplotypecount << endl;
   
   /******************
     write corrected
@@ -476,7 +476,7 @@ int main(int argc, char** argv){
   
   cleanup();
   (void) time(&t1);
-  stat_file << "# after sampling took " << difftime(t1, t2) << " seconds";
+  stat_file << "# after sampling took " << difftime(t1, t2) << " seconds" << endl;
   /*
   tn = mxt;
   cnode* tn2;
@@ -629,8 +629,8 @@ void read_conversion(crnode* b, unsigned short int* a, int seq_length){
 
   for(i=0; i<seq_length/10; i++){
     for(j=10; j>0; j--){
-      temp = (int) pow(8.0, (double)j-1);
-      b->creads[i] += temp * a[10 * i + 10 - j];
+      // NOTE: slightly faster version using bitwise left shift operator 
+      b->creads[i] += a[10*(i+1)-j] << 3*(j-1);
       b->missing += (a[10 * i + 10 - j] == B);
     }
   }
@@ -791,7 +791,7 @@ void build_assignment(ofstream& out_file){
   int* temp;
   temp = new int[J/10+1];
   conversion(temp, cn->h, J);
-  for (ll=0; ll < q; ll++){
+  for(ll=0; ll < q; ll++){
     p = seq_distance_new(temp, readtable2[ll], J);
     cn->rd0[ll] = p.first;
     cn->rd1[ll] = p.second;
@@ -860,7 +860,7 @@ void build_assignment(ofstream& out_file){
   for(i=0; i<n; i++)
     printf("predecessor of %i is %p\n", i, c_ptr[i]);
   */
-  unsigned short int rr;
+  unsigned int rr;
   
   int bmax = 0;
   unsigned short int bi;
@@ -870,7 +870,7 @@ void build_assignment(ofstream& out_file){
     for(rr=0;rr<B;rr++)
       cbase[rr] = 0;
     
-    for (rr=0; rr<q; rr++) {
+    for(rr=0; rr<q; rr++){
       if(r[readtable2[rr]->mindex][i] < B) {
      	//cbase[r[rr][i]]++;
         cbase[r[readtable2[rr]->mindex][i]] += readtable2[rr]->weight;
@@ -1567,7 +1567,7 @@ ssret* sample_class(unsigned int i, unsigned int step){
     
     else if (to_class == NULL){
 #ifdef DEBUG    
-      printf("moving %i to a new class from %p\n", index, from_class);
+      printf("moving %i to a new class from %p\n", i, from_class);
 #endif
       
       remove_read( search_read(&from_class->rlist, i) );

--- a/src/shorah/dpm_sampler.cpp
+++ b/src/shorah/dpm_sampler.cpp
@@ -82,11 +82,10 @@ int main(int argc, char** argv){
   ofstream out_file(outstr.c_str());
   ofstream stat_file(statstr.c_str());
   
-  stat_file << "# dna_code:\t";
-  stat_file << i2dna_code;
+  stat_file << "# dna_code:\t" << i2dna_code << endl;
   
   //  randseed = 1257501510;
-  stat_file << "# randseed = " << randseed << "\n";
+  stat_file << "# randseed = " << randseed << endl;
   
   // random number generator via gsl
   gsl_rng_env_setup();
@@ -94,8 +93,6 @@ int main(int argc, char** argv){
   rg = gsl_rng_alloc(T);
   gsl_rng_set(rg, randseed);
   
-  dist = (int*)calloc(2, sizeof(int));
-  if (dist == NULL) exit(EXIT_FAILURE);
   res_dist = (int*)calloc(2, sizeof(int));
   if (res_dist == NULL) exit(EXIT_FAILURE);
   res = (ssret*)malloc(sizeof(ssret));
@@ -144,7 +141,7 @@ int main(int argc, char** argv){
   for(i=0; i<n; i++){
     readtable[i] = (crnode*)calloc(1, sizeof(crnode));
     readtable[i]->creads = new int[J/10 + 1];
-    readtable[i]->mindices = new int[LIMIT + 1];
+    readtable[i]->mindices = new int;      //instantiated, although not used
   }
 
   for(i=0; i<n; i++){
@@ -215,72 +212,72 @@ int main(int argc, char** argv){
     }
   }
        
-   /*  
+  /*  
 
-   for(i=0; i<n; i++){
-     hd = seq_distance_rr(readtable[i]->creads, readtable[readtable[i]->mindex], J); 
-     cout<<" Read "<<i<<" is mapped to "<<readtable[i]->mindex<<" with distance = "<<hd[0]<<" and has weight = "<<readtable[i]->weight<<endl;
-   }
-   */
-   //q = readmap.size();
-   q = 0;
+  for(i=0; i<n; i++){
+    hd = seq_distance_rr(readtable[i]->creads, readtable[readtable[i]->mindex], J); 
+    cout<<" Read "<<i<<" is mapped to "<<readtable[i]->mindex<<" with distance = "<<hd[0]<<" and has weight = "<<readtable[i]->weight<<endl;
+  }
+  */
+  //q = readmap.size();
+  q = 0;
 
-   for(i=0; i<n; i++){
-     if(readtable[i]->weight > 0)
-       q++;
-   }
+  for(i=0; i<n; i++){
+    if(readtable[i]->weight > 0)
+      q++;
+  }
 
-   stat_file << "# q = "<<q<<endl;
+  stat_file << "# q = " << q << endl;
 
-   readtable2 = (crnode**)calloc(q, sizeof(crnode*));
+  readtable2 = (crnode**)calloc(q, sizeof(crnode*));
 
-   for(i=0; i<q; i++){
-     readtable2[i] = (crnode*)malloc(sizeof(crnode));
-     //  readtable2[i]->creads = new int[J/10 + 1];
-     readtable2[i]->weight = 0;
-     readtable2[i]->mindex = 0;
-     readtable2[i]->mindices = new int[LIMIT + 1];
-   }
-   
-   int wcount;
+  for(i=0; i<q; i++){
+    readtable2[i] = (crnode*)malloc(sizeof(crnode));
+    //  readtable2[i]->creads = new int[J/10 + 1];
+    readtable2[i]->weight = 0;
+    readtable2[i]->mindex = 0;
+    readtable2[i]->mindices = new int[LIMIT + 1]; 
+  }
+  
+  int wcount;
 
-   for(i=0; i<q; i++){
-     for(wcount=0; wcount<LIMIT + 1; wcount++)
-       readtable2[i]->mindices[wcount] = 0;
-   }
+  for(i=0; i<q; i++){
+    for(wcount=0; wcount<LIMIT + 1; wcount++)
+      readtable2[i]->mindices[wcount] = 0;
+  }
 
-   j = 0;
-   unsigned int hope;
-   int* itrack = new int[q];
+  j = 0;
+  unsigned int hope;
+  int* itrack = new int[q];
 
-   for(i=0; i<q; i++)
-     itrack[i] = 0;
+  for(i=0; i<q; i++)
+    itrack[i] = 0;
 
-   for(i=0; i<n; i++){
-     if(readtable[i]->weight > 0){
-       readtable2[j]->creads = readtable[i]->creads;
-       readtable2[j]->missing = readtable[i]->missing;
-       readtable2[j]->mindex = i;
-       readtable2[j]->weight = readtable[i]->weight;
-       readtable2[j]->mindices[0] = i;
-       itrack[j]++;
-       j++;
-     }
-     else{
-       for(hope=0; hope<j; hope++){
-	 if(readtable2[hope]->mindex == readtable[i]->mindex){
-	   readtable2[hope]->mindices[itrack[hope]] = i;
-	   itrack[hope]++;
-	 }
-       }
-     }
-   }
+  for(i=0; i<n; i++){
+    if(readtable[i]->weight > 0){
+      readtable2[j]->creads = readtable[i]->creads;
+      readtable2[j]->missing = readtable[i]->missing;
+      readtable2[j]->mindex = i;
+      readtable2[j]->weight = readtable[i]->weight;
+      readtable2[j]->mindices[0] = i;
+      itrack[j]++;
+      j++;
+    }
+    else{
+      for(hope=0; hope<j; hope++){
+        if(readtable2[hope]->mindex == readtable[i]->mindex){
+          readtable2[hope]->mindices[itrack[hope]] = i;
+          itrack[hope]++;
+        }
+      }
+    }
+  }
 
 
   delete[] itrack;
   build_assignment(stat_file);
 
-  stat_file << "# Assignment built"<<endl;
+  stat_file << "# Assignment built" << endl;
 
   stat_file << "# +++++++++++++++++++ BEFORE THE SAMPLING +++++++++++++++++++\n";
   //  print_stats(out_file, mxt, J);
@@ -314,16 +311,16 @@ int main(int argc, char** argv){
       fclose(alphafile);
     }
 
-    /// Modify alpha reading from an external file
+    /// Modify iter reading from an external file
     iterfile = fopen(iterstr.c_str(), "r");
     if (iterfile != NULL){
       fscanf(iterfile, "%ui", &iter2);
       if (iter != iter2 and iter2 > k+100){
-	if (iter2 < iter){
-	  HISTORY = iter2 - k - 1;
-	  cerr << "HISTORY just changed to " << HISTORY << endl;
-	}
-	iter = iter2;
+        if (iter2 < iter){
+          HISTORY = iter2 - k - 1;
+          cerr << "HISTORY just changed to " << HISTORY << endl;
+        }
+        iter = iter2;
       }
       fclose(iterfile);
     }
@@ -722,7 +719,7 @@ void build_assignment(std::ofstream& out_file){
   //double* p_q;
   gsl_ran_discrete_t* g;
   
-  out_file << "# building assignment\n";
+  out_file << "# Building assignment" << endl;
   h = (short unsigned int*)calloc(J, sizeof(unsigned int));
   c_ptr = (cnode**)calloc(n, sizeof(cnode*));
 
@@ -748,7 +745,7 @@ void build_assignment(std::ofstream& out_file){
 
   // make the class list of K (or q?) initial components 
 
-  out_file << "# Initial number of clusters, K = "<<K<<endl;
+  out_file << "# Initial number of clusters, K = " << K << endl;
 
   mxt = NULL;
   for(i=0; i<K; i++) {
@@ -764,9 +761,9 @@ void build_assignment(std::ofstream& out_file){
     cn = mxt;
     while(cn != NULL) {
       if(ci == cn->ci){
-	add_read(&cn->rlist, m);
-	cn->size++;
-	break;
+        add_read(&cn->rlist, m);
+        cn->size++;
+        break;
       }
       cn=cn->next;
     }
@@ -825,9 +822,9 @@ void build_assignment(std::ofstream& out_file){
       sample_hap(cn->next);
       conversion(temp, cn->next->h, J);
       for (ll=0; ll < q; ll++){
-	p = seq_distance_new(temp, readtable2[ll], J);
-	cn->next->rd0[ll] = p.first;
-	cn->next->rd1[ll] = p.second;
+        p = seq_distance_new(temp, readtable2[ll], J);
+        cn->next->rd0[ll] = p.first;
+        cn->next->rd1[ll] = p.second;
       }
       cn = cn->next;
     }
@@ -873,19 +870,19 @@ void build_assignment(std::ofstream& out_file){
     for (rr=0; rr<q; rr++) {
       if(r[readtable2[rr]->mindex][i] < B) {
      	//cbase[r[rr][i]]++;
-	cbase[r[readtable2[rr]->mindex][i]] += readtable2[rr]->weight;
-	//bmax += 1;
-	bmax += readtable2[rr]->weight;
+        cbase[r[readtable2[rr]->mindex][i]] += readtable2[rr]->weight;
+        //bmax += 1;
+        bmax += readtable2[rr]->weight;
       }
     }
     if(bmax > 0) { 
       bmax = cbase[0];
       bi = 0;
       for(rr=1; rr<B; rr++) {
-	if(cbase[rr] > bmax) {
-	  bmax = cbase[rr];
-	  bi = rr;
-	}
+        if(cbase[rr] > bmax) {
+          bmax = cbase[rr];
+          bi = rr;
+        }
       }
       h[i] = bi;
     }

--- a/src/shorah/dpm_sampler.hpp
+++ b/src/shorah/dpm_sampler.hpp
@@ -32,7 +32,7 @@ const unsigned int B=5; //characters in the alphabet
 const int one_int = 153391689;
 const int two_int = 306783378;
 const int four_int = 613566756;
-const int LIMIT = 100;//000;
+const int LIMIT = 100000;
 
 char* filein;
 char** id;
@@ -139,11 +139,11 @@ int isdna(char c);
 
 unsigned int d2i(char c);
 
-int* seq_distance_new(int* A, crnode* B, int seq_length);
+std::pair<int,int> seq_distance_new(int* A, crnode* B, int seq_length);
 
-int* seq_distance_rr(int* A, crnode* B, int seq_length);
+std::pair<int,int> seq_distance_rr(int* A, crnode* B, int seq_length);
 
-int* seq_distance(unsigned short int* a, unsigned short int* b, int seq_length);
+std::pair<int,int> seq_distance(unsigned short int* a, unsigned short int* b, int seq_length);
 
 ssret* sample_class(unsigned int i,unsigned int step);
 

--- a/src/shorah/dpm_sampler.hpp
+++ b/src/shorah/dpm_sampler.hpp
@@ -45,7 +45,6 @@ int* ftable_sum;
 //int** creads;
 unsigned short int* h;
 ssret* res;
-int* dist;
 int* res_dist;
 int* cbase;
 double* pbase;

--- a/src/shorah/dpm_sampler.hpp
+++ b/src/shorah/dpm_sampler.hpp
@@ -126,11 +126,9 @@ void read_conversion(crnode* b, unsigned short int* a, int seq_length);
 
 void conversion(int* b, unsigned short int* a, int seq_length);
 
-int weight(cnode* wn);
+int weight(const cnode* wn);
 
-int weight_shift(cnode* wn, unsigned int i);
-
-int weight_final(const cnode* wn);
+int weight_shift(const cnode* wn, unsigned int i, unsigned int removed);
 
 void build_assignment(std::ofstream& out_file);
 

--- a/src/shorah/fil.cpp
+++ b/src/shorah/fil.cpp
@@ -16,7 +16,7 @@ adapted from samtools/calDep.c
 using namespace std;
 
 typedef struct {
-    int pos, pos1, SNP, forwM, revM, forwT, revT;
+    int pos, pos1, SNP, forwM, revM, forwT, revT, maxdepth;
     double sig, pval;
     char nuc;
     samfile_t *in;
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
     int c = 0;
     bam_index_t *idx;
 	int amplicon = 0;
-    while((c=getopt(argc, argv, "b:v:a"))!=EOF){
+    while((c=getopt(argc, argv, "b:v:x:a"))!=EOF){
         switch(c){
 			case 'b':
             	tmp.in = samopen(optarg, "rb", 0);
@@ -144,6 +144,9 @@ int main(int argc, char *argv[])
 			case 'v':
             	tmp.sig = atof(optarg);
 				break;
+            case 'x':
+                tmp.maxdepth = atoi(optarg);
+                break;
 			case 'a':
 				amplicon = 1;
         }
@@ -156,11 +159,9 @@ int main(int argc, char *argv[])
         fprintf(stderr, "BAM indexing file is not available.\n");
         return 2;
     }
-    int maxdepth;
-    maxdepth = 100000;
     bam_plbuf_t *buf;
     buf = bam_plbuf_init(pileup_func, &tmp);
-    bam_plp_set_maxcnt(buf->iter, maxdepth);
+    bam_plp_set_maxcnt(buf->iter, tmp.maxdepth);
     FILE *fl = fopen("SNV.txt","rt");
     if (fl==NULL){
         fprintf(stderr, "Failed to open SNV file.\n");


### PR DESCRIPTION
Main changes are listed below 

1. Intel intrinsic for counting bits, POPCNT, has been added as an alternative way of computing Hamming distances between reads. It is used only when the intrinsic is available, otherwise previous implementation is used. 

2. The limit on the number of reads which can be group together as unique reads has been extended from 100 to 100000. The gain on performance is at the expense of increased memory. However, this allows to run ShoRAH on large datasets (over million reads, e.g. using HiSeq) on a reasonable time scale. On the other hand, when the read depth is of the order of ten thousand, max. memory is of the order of 27 GB. 

3. Cluster sizes taking into account read weights (unique reads represent one or more identical reads) is updated as reads are added or removed. 

4. Corrected reads are merged using multiple threads (multiprocessing module). 

5. Seeds are added to ensure reproducibility  