### PR TITLE
Codebase polishes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+BasedOnStyle:  Google
+BreakBeforeBraces: Mozilla
+
+AllowShortLoopsOnASingleLine: false
+AccessModifierOffset: -4
+BreakConstructorInitializersBeforeComma: true
+ColumnLimit: 100
+IndentWidth: 4
+DerivePointerAlignment: false
+PointerAlignment: Left
+TabWidth: 4
+
+ReflowComments: true
+KeepEmptyLinesAtTheStartOfBlocks: true

--- a/README.md
+++ b/README.md
@@ -128,3 +128,10 @@ The whole global reconstruction consists of the following steps:
 
 These can be run one after the other, or one can invoke `shorah.py`, that runs
 the whole process from bam file to frequency estimation and SNV calling.
+
+## Coding style
+All changes to the C++ code in `src/shorah` should always be formatted according to the included `.clang-format` style by doing
+
+	clang-format -style=file -i src/shorah/*.[ch]pp
+
+in the root of the repository.

--- a/src/shorah/b2w.cpp
+++ b/src/shorah/b2w.cpp
@@ -31,15 +31,13 @@ adapted from samtools/calDep.c
  ******************************/
 
 #include <getopt.h>
-#include <stdio.h>
+#include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <string>
 #include "faidx.h"
 #include "sam.h"
-
-using namespace std;
 
 // data for fetch_func and pileup_func
 typedef struct
@@ -155,7 +153,7 @@ int main(int argc, char* argv[])
     int ref = 0;         // index for retrieving reference chromosome
     char filename[100];  // filename for window files
 
-    ofstream covOut;  // stores window coverages
+    std::ofstream covOut;  // stores window coverages
 
     tmpstruct_t tmp;  // data for callback functions
 
@@ -210,8 +208,8 @@ int main(int argc, char* argv[])
     n = tmp.in->header->n_targets;                // number of chromosomes
     ln = tmp.in->header->target_len;              // chromosome lengths
     tmp.buf = bam_plbuf_init(pileup_func, &tmp);  // initiate pileup buffer
-    covOut.open("coverage.txt", ios::out);        // open file to store window coverage
-    tmp.reads.open("reads.fas", ios::out);
+    covOut.open("coverage.txt", std::ios::out);   // open file to store window coverage
+    tmp.reads.open("reads.fas", std::ios::out);
     if (argc == optind + 2) {          // region not specified
         for (int i = 0; i < n; i++) {  // take each chromosome in turn
             int lnth = (int)ln[i];     // chromosome length
@@ -237,7 +235,7 @@ int main(int argc, char* argv[])
                 tmp.rLen = rLen;
                 sprintf(filename, "w-%s-%d-%d.reads.fas",  // read window filename
                         tmp.in->header->target_name[i], tmp.beg + 1, tmp.end + 1);
-                tmp.outFile.open(filename, ios::out);
+                tmp.outFile.open(filename, std::ios::out);
                 bam_fetch(tmp.in->x.bam, idx, i, tmp.beg, tmp.end, &tmp,
                           fetch_func1);         // fetch and write reads
                 if (tmp.cov != 0) {             // ignore empty windows
@@ -288,7 +286,7 @@ int main(int argc, char* argv[])
             tmp.rLen = rLen;
             sprintf(filename, "w-%s-%d-%d.reads.fas",  // read window filename
                     tmp.in->header->target_name[ref], tmp.beg + 1, tmp.end + 1);
-            tmp.outFile.open(filename, ios::out);
+            tmp.outFile.open(filename, std::ios::out);
             bam_fetch(tmp.in->x.bam, idx, ref, tmp.beg, tmp.end, &tmp,
                       fetch_func1);  // fetch and write reads
             if (tmp.cov != 0) {      // ignore empty windows

--- a/src/shorah/b2w.cpp
+++ b/src/shorah/b2w.cpp
@@ -24,299 +24,289 @@
 */
 
 /******************************
-b2w.c
+b2w.cpp
 Kerensa McElroy
 UNSW, Sydney Australia
 adapted from samtools/calDep.c
  ******************************/
 
-#include <stdio.h>
-#include "sam.h"
-#include "faidx.h"
-#include <map>
 #include <getopt.h>
-#include <iostream>
+#include <stdio.h>
 #include <fstream>
+#include <iostream>
+#include <map>
 #include <string>
+#include "faidx.h"
+#include "sam.h"
 
 using namespace std;
 
-//data for fetch_func and pileup_func 
-typedef struct {
-	int b, e, win, inc, min_overlap, len, cov, max;
-	samfile_t *in;
-    uint32_t beg, end; //b, e store begin and end of entire region of interest
-    bam_plbuf_t *buf; //beg, end store begin and end of current window
-    faidx_t *fai;
-    void *rd; //stores working read
-    void *rLen; //stores coverage of read starts on reference
-    ofstream outFile; //output file for current window
-    ofstream reads;
+// data for fetch_func and pileup_func
+typedef struct
+{
+    int b, e, win, inc, min_overlap, len, cov, max;
+    samfile_t* in;
+    uint32_t beg, end;  // b, e store begin and end of entire region of interest
+    bam_plbuf_t* buf;   // beg, end store begin and end of current window
+    faidx_t* fai;
+    void* rd;               // stores working read
+    void* rLen;             // stores coverage of read starts on reference
+    std::ofstream outFile;  // output file for current window
+    std::ofstream reads;
 } tmpstruct_t;
 
-//callback one for bam_fetch() (for making windows)
-static int fetch_func1(const bam1_t *b, void *data)
+// callback one for bam_fetch() (for making windows)
+static int fetch_func1(const bam1_t* b, void* data)
 {
-	tmpstruct_t *tmp = (tmpstruct_t*)data;
-    int overlap = 0; //read overlap with window
-    int wSize; //window size
-    uint32_t Rstart, Rend; //read start and end
+    tmpstruct_t* tmp = (tmpstruct_t*)data;
+    int overlap = 0;        // read overlap with window
+    int wSize;              // window size
+    uint32_t Rstart, Rend;  // read start and end
 
     Rstart = b->core.pos;
     Rend = bam_calend(&b->core, bam1_cigar(b));
     wSize = tmp->win;
 
-    int *cv=(int*)tmp->rLen+Rstart; //tracks nr of reads starting at ref pos
+    int* cv = (int*)tmp->rLen + Rstart;  // tracks nr of reads starting at ref pos
     *cv += 1;
 
-    if (*cv<tmp->max) { //limit coverage
-        if (Rstart <= tmp->beg && Rend >= tmp->end) { //calculate overlap
-        	overlap = tmp->end - tmp->beg + 1;
-        }
-        else if (Rstart >= tmp->beg && Rend <= tmp->end){
-        	overlap = Rend - Rstart +1;
-        }
-        else if (Rstart <= tmp->beg && Rend <= tmp->end){
-        	overlap = Rend - tmp->beg +1;
-        }
-        else if (Rstart >= tmp->beg && Rend >= tmp->end){
-        	overlap = tmp->end - Rstart +1;
+    if (*cv < tmp->max) {                              // limit coverage
+        if (Rstart <= tmp->beg && Rend >= tmp->end) {  // calculate overlap
+            overlap = tmp->end - tmp->beg + 1;
+        } else if (Rstart >= tmp->beg && Rend <= tmp->end) {
+            overlap = Rend - Rstart + 1;
+        } else if (Rstart <= tmp->beg && Rend <= tmp->end) {
+            overlap = Rend - tmp->beg + 1;
+        } else if (Rstart >= tmp->beg && Rend >= tmp->end) {
+            overlap = tmp->end - Rstart + 1;
         }
         if (overlap >= tmp->min_overlap) {
-            char rd[wSize+1]; //store blank read segment of 'N's
-            for (int i=0; i<wSize; i++){
-            	rd[i]='N';
+            char rd[wSize + 1];  // store blank read segment of 'N's
+            for (int i = 0; i < wSize; i++) {
+                rd[i] = 'N';
             }
-            rd[wSize]=0;
-            tmp->rd=rd;
-            bam_plbuf_push(b, tmp->buf); //push a read to pileup buffer     
-            tmp->cov+=1; //increment window coverage
-            bam_plbuf_push(0, tmp->buf); //but make sure only 1 read at a time
+            rd[wSize] = 0;
+            tmp->rd = rd;
+            bam_plbuf_push(b, tmp->buf);  // push a read to pileup buffer
+            tmp->cov += 1;                // increment window coverage
+            bam_plbuf_push(0, tmp->buf);  // but make sure only 1 read at a time
             bam_plbuf_reset(tmp->buf);
-            tmp->outFile //write read header 
-            << '>' 
-            << bam1_qname(b) 
-            << ' '
-            << Rstart 
-            << '\n';
-            tmp->outFile //write read 
-            << rd 
-            << "\n";
+            tmp->outFile  // write read header
+                << '>' << bam1_qname(b) << ' ' << Rstart << '\n';
+            tmp->outFile  // write read
+                << rd << "\n";
         }
     }
     return 0;
 }
 
-//callback for bam_plbuf_init() (for making windows)
-static int pileup_func(uint32_t tid, uint32_t pos, int n, const bam_pileup1_t *pl, void *data)
+// callback for bam_plbuf_init() (for making windows)
+static int pileup_func(uint32_t tid, uint32_t pos, int n, const bam_pileup1_t* pl, void* data)
 {
-	tmpstruct_t *tmp = (tmpstruct_t*)data;
-    int i = pos - tmp->beg; //base position within window
-    char *mm=(char*)tmp->rd + i; //location of base
-    if (pos >= tmp->beg && pos <= tmp->end) { //make sure read position within window
-        if (pl->is_del==1) { //remove deletions, replacing with reference
-// char *rb;
-// int td;
-// td = pl->b->core.tid;
-// rb = fai_fetch(tmp->fai, tmp->in->header->target_name[td], &tmp->len);
-        	*mm='-';
+    tmpstruct_t* tmp = (tmpstruct_t*)data;
+    int i = pos - tmp->beg;                    // base position within window
+    char* mm = (char*)tmp->rd + i;             // location of base
+    if (pos >= tmp->beg && pos <= tmp->end) {  // make sure read position within window
+        if (pl->is_del == 1) {                 // remove deletions, replacing with reference
+            // char *rb;
+            // int td;
+            // td = pl->b->core.tid;
+            // rb = fai_fetch(tmp->fai, tmp->in->header->target_name[td], &tmp->len);
+            *mm = '-';
+        } else {  // replace 'N' in tmp.read with current read base
+            *mm = bam_nt16_rev_table[bam1_seqi(bam1_seq(pl->b), pl->qpos)];
         }
-        else { //replace 'N' in tmp.read with current read base 
-        	*mm=bam_nt16_rev_table[bam1_seqi(bam1_seq(pl->b),pl->qpos)];
     }
-}
-return 0;
+    return 0;
 }
 
-//callback two (for printing reads)
-static int fetch_func2(const bam1_t *b, void *data)
+// callback two (for printing reads)
+static int fetch_func2(const bam1_t* b, void* data)
 {
-	tmpstruct_t *tmp = (tmpstruct_t*)data;
-	uint32_t Rstart,Rend;
-	Rstart=b->core.pos;
-	Rend=bam_calend(&b->core, bam1_cigar(b));
-	int *cv=(int*)tmp->rLen+Rstart;
-	*cv+=1;
-	int readLen=Rend-Rstart;
-	if ((*cv<tmp->max) && (readLen>=tmp->min_overlap)) {
-		char rd[readLen+1];
-		for (int i=0;i<readLen;i++){
-			rd[i]='N';
-		}
-		rd[readLen]=0;
-		tmp->rd=rd;
-		tmp->beg=Rstart;
-		tmp->end=Rend;
-		bam_plbuf_push(b, tmp->buf);
-		bam_plbuf_push(0,tmp->buf);
-		bam_plbuf_reset(tmp->buf);
-		tmp->reads << bam1_qname(b) << "\t"
-		<< tmp->b << "\t"
-		<< tmp->e << "\t"
-		<< Rstart+1 << "\t"
-		<< Rend << "\t"
-		<< rd << "\n";
-	}
-	return 0;
+    tmpstruct_t* tmp = (tmpstruct_t*)data;
+    uint32_t Rstart, Rend;
+    Rstart = b->core.pos;
+    Rend = bam_calend(&b->core, bam1_cigar(b));
+    int* cv = (int*)tmp->rLen + Rstart;
+    *cv += 1;
+    int readLen = Rend - Rstart;
+    if ((*cv < tmp->max) && (readLen >= tmp->min_overlap)) {
+        char rd[readLen + 1];
+        for (int i = 0; i < readLen; i++) {
+            rd[i] = 'N';
+        }
+        rd[readLen] = 0;
+        tmp->rd = rd;
+        tmp->beg = Rstart;
+        tmp->end = Rend;
+        bam_plbuf_push(b, tmp->buf);
+        bam_plbuf_push(0, tmp->buf);
+        bam_plbuf_reset(tmp->buf);
+        tmp->reads << bam1_qname(b) << "\t" << tmp->b << "\t" << tmp->e << "\t" << Rstart + 1
+                   << "\t" << Rend << "\t" << rd << "\n";
+    }
+    return 0;
 }
 
-//main
-int main(int argc, char *argv[])
+// main
+int main(int argc, char* argv[])
 {
-    int c = 0; //for parsing command line arguments
-    int ref = 0; //index for retrieving reference chromosome
-    char filename [100]; //filename for window files
+    int c = 0;           // for parsing command line arguments
+    int ref = 0;         // index for retrieving reference chromosome
+    char filename[100];  // filename for window files
 
-    ofstream covOut; //stores window coverages
+    ofstream covOut;  // stores window coverages
 
-    tmpstruct_t tmp; //data for callback functions
+    tmpstruct_t tmp;  // data for callback functions
 
-    char help_string[] = "\nUsage: b2w [options] <in.bam> <in.fasta> region\n\nOptions:\n\t-w: window length (INT)\n\t-i: increment (INT)\n\t-m: minimum overlap (INT)\n\t-x: max reads starting at a position (INT)\n\t-h: show this help\n\n";
+    char help_string[] =
+        "\nUsage: b2w [options] <in.bam> <in.fasta> region\n\nOptions:\n\t-w: window length "
+        "(INT)\n\t-i: increment (INT)\n\t-m: minimum overlap (INT)\n\t-x: max reads starting at a "
+        "position (INT)\n\t-h: show this help\n\n";
 
-    while((c = getopt(argc, argv, "w:i:m:x:h")) != EOF)
-    {
-    	switch(c)
-    	{
-    		case 'w':
-    		tmp.win = atof(optarg);
-    		break;
-    		case 'i':
-    		tmp.inc = atof(optarg);
-    		break;
-    		case 'm':
-    		tmp.min_overlap = atof(optarg);
-    		break;
-    		case 'x':
-    		tmp.max = atof(optarg);
-    		break;
-    		case 'h':
-    		fprintf(stderr, "%s", help_string);
-    		return 1;
-    	}
+    while ((c = getopt(argc, argv, "w:i:m:x:h")) != EOF) {
+        switch (c) {
+            case 'w':
+                tmp.win = atof(optarg);
+                break;
+            case 'i':
+                tmp.inc = atof(optarg);
+                break;
+            case 'm':
+                tmp.min_overlap = atof(optarg);
+                break;
+            case 'x':
+                tmp.max = atof(optarg);
+                break;
+            case 'h':
+                fprintf(stderr, "%s", help_string);
+                return 1;
+        }
     }
     if (argc < 11 || argc > 12) {
-    	fprintf(stderr, "%s", help_string);
-    	return 1;
+        fprintf(stderr, "%s", help_string);
+        return 1;
     }
 
-    tmp.in = samopen(argv[optind], "rb", 0); //open bam file
+    tmp.in = samopen(argv[optind], "rb", 0);  // open bam file
     if (tmp.in == 0) {
-    	fprintf(stderr, "Failed to open BAM file %s\n", argv[optind]);
-    	return 2;
+        fprintf(stderr, "Failed to open BAM file %s\n", argv[optind]);
+        return 2;
     }
 
-    fai_build(argv[optind + 1]); //generate reference index
+    fai_build(argv[optind + 1]);  // generate reference index
     tmp.fai = fai_load(argv[optind + 1]);
 
-    int iBuild = bam_index_build(argv[optind]); //generate bam index
-    bam_index_t *idx;
-    idx = bam_index_load(argv[optind]); //load bam index
+    int iBuild = bam_index_build(argv[optind]);  // generate bam index
+    bam_index_t* idx;
+    idx = bam_index_load(argv[optind]);  // load bam index
     if (idx == 0) {
-    	fprintf(stderr, "BAM indexing file is not available.\n");
-    	return 3;
+        fprintf(stderr, "BAM indexing file is not available.\n");
+        return 3;
     }
 
     int32_t n;
-    uint32_t *ln;
-    n = tmp.in->header->n_targets; //number of chromosomes
-    ln = tmp.in->header->target_len; //chromosome lengths
-    tmp.buf = bam_plbuf_init(pileup_func, &tmp); //initiate pileup buffer
-    covOut.open("coverage.txt", ios::out); //open file to store window coverage
+    uint32_t* ln;
+    n = tmp.in->header->n_targets;                // number of chromosomes
+    ln = tmp.in->header->target_len;              // chromosome lengths
+    tmp.buf = bam_plbuf_init(pileup_func, &tmp);  // initiate pileup buffer
+    covOut.open("coverage.txt", ios::out);        // open file to store window coverage
     tmp.reads.open("reads.fas", ios::out);
-    if (argc == optind + 2) { //region not specified
-        for (int i=0; i < n; i++) { //take each chromosome in turn
-            int lnth = (int)ln[i]; //chromosome length
-            tmp.b=0;
-            tmp.len=lnth;
-            tmp.e=lnth;
-            int rLen[lnth]; //list for read start coverage
-            for (int j=0;j<lnth;j++){
-            	rLen[j]=0;
+    if (argc == optind + 2) {          // region not specified
+        for (int i = 0; i < n; i++) {  // take each chromosome in turn
+            int lnth = (int)ln[i];     // chromosome length
+            tmp.b = 0;
+            tmp.len = lnth;
+            tmp.e = lnth;
+            int rLen[lnth];  // list for read start coverage
+            for (int j = 0; j < lnth; j++) {
+                rLen[j] = 0;
             }
-            tmp.rLen=rLen;
+            tmp.rLen = rLen;
 
-            bam_fetch(tmp.in->x.bam, idx, i, tmp.b, tmp.e, &tmp, fetch_func2); //fetch and write reads
+            bam_fetch(tmp.in->x.bam, idx, i, tmp.b, tmp.e, &tmp,
+                      fetch_func2);  // fetch and write reads
             tmp.beg = 0;
             tmp.end = tmp.win - 1;
-            while (tmp.end <= ln[i] - 1) { //make windows over length of chromosome
-            	tmp.cov = 0;
-                for (int j=0; j < lnth; j++){ //restart read start coverage count for each window
-                	rLen[j]=0;
+            while (tmp.end <= ln[i] - 1) {  // make windows over length of chromosome
+                tmp.cov = 0;
+                for (int j = 0; j < lnth;
+                     j++) {  // restart read start coverage count for each window
+                    rLen[j] = 0;
                 }
                 tmp.rLen = rLen;
-                sprintf(filename, "w-%s-%d-%d.reads.fas", //read window filename
-                	tmp.in->header->target_name[i],
-                	tmp.beg+1, tmp.end+1);
-                tmp.outFile.open(filename, ios::out);    
-                bam_fetch(tmp.in->x.bam, idx, i, tmp.beg, tmp.end, &tmp, fetch_func1); //fetch and write reads
-                if (tmp.cov != 0){ //ignore empty windows
-                    covOut << filename << "\t" //write out coverage information
-                    << tmp.in->header->target_name[i] << "\t"
-                    << tmp.beg+1 << "\t" 
-                    << tmp.end+1 << "\t" 
-                    << tmp.cov << "\n";
+                sprintf(filename, "w-%s-%d-%d.reads.fas",  // read window filename
+                        tmp.in->header->target_name[i], tmp.beg + 1, tmp.end + 1);
+                tmp.outFile.open(filename, ios::out);
+                bam_fetch(tmp.in->x.bam, idx, i, tmp.beg, tmp.end, &tmp,
+                          fetch_func1);         // fetch and write reads
+                if (tmp.cov != 0) {             // ignore empty windows
+                    covOut << filename << "\t"  // write out coverage information
+                           << tmp.in->header->target_name[i] << "\t" << tmp.beg + 1 << "\t"
+                           << tmp.end + 1 << "\t" << tmp.cov << "\n";
                 }
                 tmp.outFile.close();
-                tmp.beg+=tmp.inc; //increment windows
-                tmp.end+=tmp.inc;
-                if (tmp.inc == 0){break;} // OZ: in amplicon mode, one window only
+                tmp.beg += tmp.inc;  // increment windows
+                tmp.end += tmp.inc;
+                if (tmp.inc == 0) {
+                    break;
+                }  // OZ: in amplicon mode, one window only
             }
         }
-    }
-    else { //parse specific region
-    	bam_parse_region(tmp.in->header, argv[optind + 2], &ref, &tmp.b, &tmp.e);
-    	if (ref < 0) {
-    		fprintf(stderr, "Invalid region %s\n", argv[optind +2]);
-    		return 4;
-    	}
-        tmp.b -= 3 * tmp.inc; //make sure start and end of region are covered by 3 windows
-        tmp.e += 3 * tmp.inc;
-        if (tmp.b < 0){
-        	tmp.b = 0;
+    } else {  // parse specific region
+        bam_parse_region(tmp.in->header, argv[optind + 2], &ref, &tmp.b, &tmp.e);
+        if (ref < 0) {
+            fprintf(stderr, "Invalid region %s\n", argv[optind + 2]);
+            return 4;
         }
-        if ((uint32_t)tmp.e >= ln[ref]){
-        	tmp.e = ln[ref] - 1;
+        tmp.b -= 3 * tmp.inc;  // make sure start and end of region are covered by 3 windows
+        tmp.e += 3 * tmp.inc;
+        if (tmp.b < 0) {
+            tmp.b = 0;
+        }
+        if ((uint32_t)tmp.e >= ln[ref]) {
+            tmp.e = ln[ref] - 1;
         }
         int rLen[ln[ref]];
         tmp.len = ln[ref];
 
-        for (uint32_t j=0; j<ln[ref]; j++){
-        	rLen[j] = 0;
-        } 
-        tmp.rLen=rLen;
-        bam_fetch(tmp.in->x.bam, idx, ref, tmp.b, tmp.e, &tmp, fetch_func2); //fetch and write reads
+        for (uint32_t j = 0; j < ln[ref]; j++) {
+            rLen[j] = 0;
+        }
+        tmp.rLen = rLen;
+        bam_fetch(tmp.in->x.bam, idx, ref, tmp.b, tmp.e, &tmp,
+                  fetch_func2);  // fetch and write reads
         tmp.beg = tmp.b;
         tmp.end = tmp.beg + tmp.win - 1;
 
-        while (tmp.end < (uint32_t)tmp.e) { //make windows over region
-        	tmp.cov = 0;
-           for (uint32_t j=0; j<ln[ref]; j++){ //restart read start coverage count for each window
-           	rLen[j] = 0;
-           }
-           tmp.rLen = rLen;
-           sprintf(filename, "w-%s-%d-%d.reads.fas", //read window filename
-           	tmp.in->header->target_name[ref],
-           	tmp.beg + 1,
-           	tmp.end + 1); 
-           tmp.outFile.open(filename, ios::out);
-           bam_fetch(tmp.in->x.bam, idx, ref, tmp.beg, tmp.end, &tmp, fetch_func1);  //fetch and write reads
-           if (tmp.cov != 0) { //ignore empty windows
-           	covOut << filename << "\t" 
-           	<< tmp.in->header->target_name[ref] << "\t" 
-           	<< tmp.beg+1<< "\t" 
-           	<< tmp.end+1 << "\t"  
-           	<< tmp.cov << "\n";
-           }
-           tmp.outFile.close();
-           tmp.beg += tmp.inc; //increment windows
-           tmp.end += tmp.inc;
-		   if (tmp.inc == 0){break;} // OZ: in amplicon mode, one window only
-		}
-	}
-	bam_plbuf_destroy(tmp.buf);
-	bam_index_destroy(idx);
-	samclose(tmp.in);
-	covOut.close();
-	tmp.reads.close();
-	return 0;
+        while (tmp.end < (uint32_t)tmp.e) {  // make windows over region
+            tmp.cov = 0;
+            for (uint32_t j = 0; j < ln[ref];
+                 j++) {  // restart read start coverage count for each window
+                rLen[j] = 0;
+            }
+            tmp.rLen = rLen;
+            sprintf(filename, "w-%s-%d-%d.reads.fas",  // read window filename
+                    tmp.in->header->target_name[ref], tmp.beg + 1, tmp.end + 1);
+            tmp.outFile.open(filename, ios::out);
+            bam_fetch(tmp.in->x.bam, idx, ref, tmp.beg, tmp.end, &tmp,
+                      fetch_func1);  // fetch and write reads
+            if (tmp.cov != 0) {      // ignore empty windows
+                covOut << filename << "\t" << tmp.in->header->target_name[ref] << "\t"
+                       << tmp.beg + 1 << "\t" << tmp.end + 1 << "\t" << tmp.cov << "\n";
+            }
+            tmp.outFile.close();
+            tmp.beg += tmp.inc;  // increment windows
+            tmp.end += tmp.inc;
+            if (tmp.inc == 0) {
+                break;
+            }  // OZ: in amplicon mode, one window only
+        }
+    }
+    bam_plbuf_destroy(tmp.buf);
+    bam_index_destroy(idx);
+    samclose(tmp.in);
+    covOut.close();
+    tmp.reads.close();
+    return 0;
 }

--- a/src/shorah/contain.cpp
+++ b/src/shorah/contain.cpp
@@ -38,20 +38,18 @@
 #include <map>
 #include <vector>
 
-using namespace std;
-
 struct Read
 {
     unsigned int pos;
     unsigned int len;
     unsigned int end;
-    string seq;
+    std::string seq;
 };
 
 void help(void)
 {
-    cout << "Usage: contain -f basename\n";
-    cout << "Expects basename.read, outputs basename.rest\n";
+    std::cout << "Usage: contain -f basename\n";
+    std::cout << "Expects basename.read, outputs basename.rest\n";
     exit(1);
 }
 
@@ -64,24 +62,24 @@ void getReads(std::istream& infile, std::vector<Read>& ans)
      */
 
     Read r;
-    string t;
-    string tmp;
-    string throwaway;
+    std::string t;
+    std::string tmp;
+    std::string throwaway;
 
     // line of file is "pos seq"
-    while (!getline(infile, tmp, ' ').eof()) {
+    while (!std::getline(infile, tmp, ' ').eof()) {
         if (tmp[0] == '#') {
-            getline(infile, throwaway);
-            cerr << "Comment : " << tmp << " " << throwaway << endl;
+            std::getline(infile, throwaway);
+            std::cerr << "Comment : " << tmp << " " << throwaway << std::endl;
             continue;
         }
         r.pos = atoi(tmp.c_str());
         if ((r.pos < 0)) {
-            cerr << "Error: " << r.pos << " is an invalid start position\n";
+            std::cerr << "Error: " << r.pos << " is an invalid start position\n";
             exit(1);
         }
 
-        getline(infile, r.seq);
+        std::getline(infile, r.seq);
         r.len = r.seq.length();
         r.end = r.pos + r.len - 1;
 
@@ -98,7 +96,7 @@ int contain(std::vector<Read>& reads, int i, int j)
     int tmp, overlap;
 
     if ((reads[i].pos > reads[j].end) || (reads[j].pos > reads[i].end)) {
-        // cout << "no overlap\n";
+        // std::cout << "no overlap\n";
         return -1;
     }
 
@@ -110,11 +108,13 @@ int contain(std::vector<Read>& reads, int i, int j)
         i = tmp;
     }
     overlap = reads[i].pos + reads[i].len - reads[j].pos;
-    // cout << "read " << i << " at pos " << reads[i].pos << " length " << reads[i].len << "\n";
-    // cout << "read " << j << " at pos " << reads[j].pos << " length " << reads[j].len << "\n";
-    // cout << "overlap == " << overlap << "\n";
+    // std::cout << "read " << i << " at pos " << reads[i].pos << " length " << reads[i].len <<
+    // "\n";
+    // std::cout << "read " << j << " at pos " << reads[j].pos << " length " << reads[j].len <<
+    // "\n";
+    // std::cout << "overlap == " << overlap << "\n";
     if (overlap < reads[j].len) {
-        //	cout << "not enough overlap\n";
+        //	std::cout << "not enough overlap\n";
         return -1;
     }
     if (overlap > reads[j].len) {
@@ -122,10 +122,10 @@ int contain(std::vector<Read>& reads, int i, int j)
     }
     if (reads[i].seq.substr(reads[j].pos - reads[i].pos, overlap) ==
         reads[j].seq.substr(0, overlap)) {
-        //	cout << "Agree\n";
+        //	std::cout << "Agree\n";
         return j;
     } else {
-        //	cout << "Disagree\n";
+        //	std::cout << "Disagree\n";
         return -1;
     }
 }
@@ -133,10 +133,10 @@ int contain(std::vector<Read>& reads, int i, int j)
 int main(int argc, char** argv)
 {
     int c;
-    vector<Read> reads;
-    string basename;
-    string filename;
-    string outfilename;
+    std::vector<Read> reads;
+    std::string basename;
+    std::string filename;
+    std::string outfilename;
     int i, j;
 
     /* parse options
@@ -166,16 +166,16 @@ int main(int argc, char** argv)
     filename = basename + ".read";
     outfilename = basename + ".rest";
 
-    ifstream infile(filename.c_str());
-    ofstream outfile(outfilename.c_str());
-    map<int, int> delReads;
+    std::ifstream infile(filename.c_str());
+    std::ofstream outfile(outfilename.c_str());
+    std::map<int, int> delReads;
 
     // pull all reads into file
     getReads(infile, reads);
     int idx;
     int finalReads = 0;
     int numDeleted = 0;
-    cout << "readfile read" << endl;
+    std::cout << "readfile read" << std::endl;
     // do double loop over all reads.
     // contain returns the index to delete: either i, j, or -1
     // should be able to speed this up by skipping i or j if
@@ -188,7 +188,7 @@ int main(int argc, char** argv)
         if (delReads[i]) {
             continue;
         }
-        if (i % 10 == 0) cout << "finished " << i << " reads, " << numDeleted << " deleted\n";
+        if (i % 10 == 0) std::cout << "finished " << i << " reads, " << numDeleted << " deleted\n";
 
         for (j = i + 1; j < reads.size(); ++j) {
             if (delReads[j]) continue;
@@ -205,7 +205,7 @@ int main(int argc, char** argv)
             }
             /*
             if (idx != -1) {
-                cout << "del " << idx << " (from " << i << " " << j  << ")\n";
+                std::cout << "del " << idx << " (from " << i << " " << j  << ")\n";
             }
             */
         }
@@ -216,6 +216,6 @@ int main(int argc, char** argv)
             outfile << reads[i].pos << " " << reads[i].seq << "\n";
         }
     }
-    cout << "Started with " << reads.size() << " reads.\n";
-    cout << "Ended with " << finalReads << " reads.\n";
+    std::cout << "Started with " << reads.size() << " reads.\n";
+    std::cout << "Ended with " << finalReads << " reads.\n";
 }

--- a/src/shorah/contain.cpp
+++ b/src/shorah/contain.cpp
@@ -1,5 +1,5 @@
-/* 
- * contain.cc -- eliminates redundant reads
+/*
+ * contain.cpp -- eliminates redundant reads
  *
  * usage: contain -f basename
  * input: basename.read
@@ -14,208 +14,208 @@
  # Kerensa McElroy
  # Osvaldo Zagordi,
  # ETH Zurich
- 
+
  # This file is part of ShoRAH.
  # ShoRAH is free software: you can redistribute it and/or modify
  # it under the terms of the GNU General Public License as published by
  # the Free Software Foundation, either version 3 of the License, or
  # (at your option) any later version.
- 
+
  # ShoRAH is distributed in the hope that it will be useful,
  # but WITHOUT ANY WARRANTY; without even the implied warranty of
  # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  # GNU General Public License for more details.
- 
+
  # You should have received a copy of the GNU General Public License
  # along with ShoRAH.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <cstdlib>
-#include <iostream>
-#include <fstream>
-#include <vector>
-#include <cmath>
-#include <map>
 #include <unistd.h>
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <vector>
 
 using namespace std;
 
-struct Read {
-	unsigned int pos;
-	unsigned int len;
-	unsigned int end;
-	string seq;
+struct Read
+{
+    unsigned int pos;
+    unsigned int len;
+    unsigned int end;
+    string seq;
 };
 
-void help (void) {
-	cout << "Usage: contain -f basename\n";
-	cout << "Expects basename.read, outputs basename.rest\n";
-	exit(1);
+void help(void)
+{
+    cout << "Usage: contain -f basename\n";
+    cout << "Expects basename.read, outputs basename.rest\n";
+    exit(1);
 }
 
-void getReads (istream & infile, vector<Read>& ans) {
-	/*
-	 * get the reads from a file/stdin
-	 * FIXME: this should be much more robust
-	   FIXME: die if the file isn't readable!!!
-	 */
+void getReads(std::istream& infile, std::vector<Read>& ans)
+{
+    /*
+     * get the reads from a file/stdin
+     * FIXME: this should be much more robust
+       FIXME: die if the file isn't readable!!!
+     */
 
-	Read r;
-	string t;
-	string tmp;
-	string throwaway;
-	
-	// line of file is "pos seq"
-	while(!getline(infile,tmp,' ').eof()) {	  
-		if (tmp[0] == '#') {
-			getline(infile,throwaway);
-			cerr << "Comment : " << tmp << " " << throwaway << endl;
-			continue;       
-		}
-		r.pos = atoi(tmp.c_str());
-		if ((r.pos < 0)) { 
-			cerr << "Error: " << r.pos << " is an invalid start position\n";
-			exit(1);
-		}
+    Read r;
+    string t;
+    string tmp;
+    string throwaway;
 
-		getline(infile,r.seq);
-		r.len = r.seq.length();
-		r.end = r.pos + r.len - 1;
+    // line of file is "pos seq"
+    while (!getline(infile, tmp, ' ').eof()) {
+        if (tmp[0] == '#') {
+            getline(infile, throwaway);
+            cerr << "Comment : " << tmp << " " << throwaway << endl;
+            continue;
+        }
+        r.pos = atoi(tmp.c_str());
+        if ((r.pos < 0)) {
+            cerr << "Error: " << r.pos << " is an invalid start position\n";
+            exit(1);
+        }
 
-		if (r.len > 0) 
-			ans.push_back(r);
-	}
+        getline(infile, r.seq);
+        r.len = r.seq.length();
+        r.end = r.pos + r.len - 1;
+
+        if (r.len > 0) ans.push_back(r);
+    }
 }
 
-int contain (vector<Read> & reads, int i, int j) {
-	// return i if read[i] contained in read[j]
-	//        j if read[j] ............ read[i]
-	//        -1 else
-	//
-	int tmp, overlap;
+int contain(std::vector<Read>& reads, int i, int j)
+{
+    // return i if read[i] contained in read[j]
+    //        j if read[j] ............ read[i]
+    //        -1 else
+    //
+    int tmp, overlap;
 
-	if ((reads[i].pos > reads[j].end) || (reads[j].pos > reads[i].end)) {
-		//cout << "no overlap\n";
-		return -1;
-	}
+    if ((reads[i].pos > reads[j].end) || (reads[j].pos > reads[i].end)) {
+        // cout << "no overlap\n";
+        return -1;
+    }
 
-	// switch so that i starts first
-	if ((reads[i].pos > reads[j].pos) || 
-			((reads[i].pos == reads[j].pos) && (reads[i].len < reads[j].len))) {
-		tmp = j;
-		j = i;
-		i = tmp;
-	}
-	overlap = reads[i].pos + reads[i].len - reads[j].pos;
-	//cout << "read " << i << " at pos " << reads[i].pos << " length " << reads[i].len << "\n";
-	//cout << "read " << j << " at pos " << reads[j].pos << " length " << reads[j].len << "\n";
-	//cout << "overlap == " << overlap << "\n";
-	if (overlap < reads[j].len) {
-	//	cout << "not enough overlap\n";
-		return -1;
-	}
-	if (overlap > reads[j].len) {
-		overlap = reads[j].len;
-	}
-	if (reads[i].seq.substr(reads[j].pos - reads[i].pos, overlap) == 
-			reads[j].seq.substr(0, overlap)) {
-	//	cout << "Agree\n";
-		return j;
-	} else {
-	//	cout << "Disagree\n";
-		return -1;
-	}
+    // switch so that i starts first
+    if ((reads[i].pos > reads[j].pos) ||
+        ((reads[i].pos == reads[j].pos) && (reads[i].len < reads[j].len))) {
+        tmp = j;
+        j = i;
+        i = tmp;
+    }
+    overlap = reads[i].pos + reads[i].len - reads[j].pos;
+    // cout << "read " << i << " at pos " << reads[i].pos << " length " << reads[i].len << "\n";
+    // cout << "read " << j << " at pos " << reads[j].pos << " length " << reads[j].len << "\n";
+    // cout << "overlap == " << overlap << "\n";
+    if (overlap < reads[j].len) {
+        //	cout << "not enough overlap\n";
+        return -1;
+    }
+    if (overlap > reads[j].len) {
+        overlap = reads[j].len;
+    }
+    if (reads[i].seq.substr(reads[j].pos - reads[i].pos, overlap) ==
+        reads[j].seq.substr(0, overlap)) {
+        //	cout << "Agree\n";
+        return j;
+    } else {
+        //	cout << "Disagree\n";
+        return -1;
+    }
 }
 
-int main (int argc, char **argv) {
-	int c;
-	vector<Read> reads;
-	string basename;
-	string filename;
-	string outfilename;
-	int i,j;
+int main(int argc, char** argv)
+{
+    int c;
+    vector<Read> reads;
+    string basename;
+    string filename;
+    string outfilename;
+    int i, j;
 
-	/* parse options
-	 * -f file (expect file.read file.geno)
-	 * -h                           (help)
-	 */
-	while (1) {
-		c = getopt (argc, argv, "f:h?");
-		if (c == -1)
-			break;
-		switch (c) {
-			case 'f':
-				basename = optarg;
-				break;
-			case '?':
-				help();
-				break;
-			case 'h':
-				help();
-				break;
-			default:
-				help();
-		}
-	}
-	if (basename == "") {
-		help();
-	}
-	filename = basename + ".read";
-	outfilename = basename + ".rest";
+    /* parse options
+     * -f file (expect file.read file.geno)
+     * -h                           (help)
+     */
+    while (1) {
+        c = getopt(argc, argv, "f:h?");
+        if (c == -1) break;
+        switch (c) {
+            case 'f':
+                basename = optarg;
+                break;
+            case '?':
+                help();
+                break;
+            case 'h':
+                help();
+                break;
+            default:
+                help();
+        }
+    }
+    if (basename == "") {
+        help();
+    }
+    filename = basename + ".read";
+    outfilename = basename + ".rest";
 
-	ifstream infile (filename.c_str());
-	ofstream outfile(outfilename.c_str());
-	map<int,int> delReads;
+    ifstream infile(filename.c_str());
+    ofstream outfile(outfilename.c_str());
+    map<int, int> delReads;
 
-	// pull all reads into file
-	getReads(infile, reads);
-	int idx;
-	int finalReads = 0;
-	int numDeleted = 0;
-	cout << "readfile read" << endl;
-	// do double loop over all reads.
-	// contain returns the index to delete: either i, j, or -1
-	// should be able to speed this up by skipping i or j if
-	// delReads[i] or j is 1
-	// but have to be careful
-	//
-	for (i = 0; i < reads.size(); ++i) {
-		// if reads[i] already deleted, then we will have already
-		// deleted everything reads[i] makes redundant
-		if (delReads[i]) {
-			continue;
-		}
-		if (i % 10 == 0) 
-			cout << "finished " << i << " reads, " << numDeleted << " deleted\n";
+    // pull all reads into file
+    getReads(infile, reads);
+    int idx;
+    int finalReads = 0;
+    int numDeleted = 0;
+    cout << "readfile read" << endl;
+    // do double loop over all reads.
+    // contain returns the index to delete: either i, j, or -1
+    // should be able to speed this up by skipping i or j if
+    // delReads[i] or j is 1
+    // but have to be careful
+    //
+    for (i = 0; i < reads.size(); ++i) {
+        // if reads[i] already deleted, then we will have already
+        // deleted everything reads[i] makes redundant
+        if (delReads[i]) {
+            continue;
+        }
+        if (i % 10 == 0) cout << "finished " << i << " reads, " << numDeleted << " deleted\n";
 
-		for (j = i + 1; j < reads.size(); ++j) {
-			if (delReads[j])
-				continue;
-			idx = contain(reads,i,j);
+        for (j = i + 1; j < reads.size(); ++j) {
+            if (delReads[j]) continue;
+            idx = contain(reads, i, j);
 
-			if (idx == i) {
-				delReads[idx] = 1;
-				// skip to next iteration of i loop
-				j = reads.size();
-				numDeleted++;
-			} else if (idx == j) {
-				delReads[idx] = 1;
-				numDeleted++;
-			}
-			/*
-			if (idx != -1) {
-				cout << "del " << idx << " (from " << i << " " << j  << ")\n";
-			}
-			*/
-		}
-	}
-	for (i = 0; i < reads.size(); ++i) {
-		if (delReads[i] != 1) {
-			finalReads++;
-			outfile << reads[i].pos << " " << reads[i].seq << "\n";
-		}
-	}
-	cout << "Started with " << reads.size() << " reads.\n";
-	cout << "Ended with " << finalReads << " reads.\n";
+            if (idx == i) {
+                delReads[idx] = 1;
+                // skip to next iteration of i loop
+                j = reads.size();
+                numDeleted++;
+            } else if (idx == j) {
+                delReads[idx] = 1;
+                numDeleted++;
+            }
+            /*
+            if (idx != -1) {
+                cout << "del " << idx << " (from " << i << " " << j  << ")\n";
+            }
+            */
+        }
+    }
+    for (i = 0; i < reads.size(); ++i) {
+        if (delReads[i] != 1) {
+            finalReads++;
+            outfile << reads[i].pos << " " << reads[i].seq << "\n";
+        }
+    }
+    cout << "Started with " << reads.size() << " reads.\n";
+    cout << "Ended with " << finalReads << " reads.\n";
 }
-

--- a/src/shorah/data_structures.hpp
+++ b/src/shorah/data_structures.hpp
@@ -274,7 +274,7 @@ void print_stats(std::ofstream& out_file, const cnode* cn, unsigned int J){
     if(p == NULL)
       out_file << "# no reads in this component\n";
 
-#ifdef DEBUG
+#ifndef NDEBUG
     if(p != NULL)
       out_file << "# reads in the list:\t";
 #endif

--- a/src/shorah/data_structures.hpp
+++ b/src/shorah/data_structures.hpp
@@ -22,15 +22,15 @@
 # along with ShoRAH.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file data_structures.h
+/** \file data_structures.hpp
     \brief A Documented file.
-    
+
     Details:
     linked list definitions
     and functions
 */
-//using std::map;
-//using std::string;
+// using std::map;
+// using std::string;
 static char i2dna_code[] = "ACGT-N";
 
 unsigned int haplotypecount = 0;
@@ -49,115 +49,115 @@ typedef struct rsa {
 } sample_rec;
 */
 
-typedef struct rtable {
-  int* creads;
-  int missing;
-  int mindex;
-  int* mindices;
-  int weight;
+typedef struct rtable
+{
+    int* creads;
+    int missing;
+    int mindex;
+    int* mindices;
+    int weight;
 } crnode;
 
-
-typedef struct rns {
-/** *********************************************************
+typedef struct rns
+{
+    /** *********************************************************
    Reads list structure: beside the pointer to the next node,
    only the int corresponding to the read index is needed.
    Methods follow.
    ********************************************************** */
-  unsigned int ri; // read index
-  struct rns* next;
+    unsigned int ri;  // read index
+    struct rns* next;
 } rnode;
 
-rnode* add_read(rnode** p, int i) {
-  //! add_read
-  rnode* n = (rnode*) malloc(sizeof(rnode));
-  
-  if(n == NULL)
+rnode* add_read(rnode** p, int i)
+{
+    //! add_read
+    rnode* n = (rnode*)malloc(sizeof(rnode));
+
+    if (n == NULL) return NULL;
+
+    n->next = *p;  // *p is a pointer (variable pointed by a double pointer)
+    *p = n;
+    n->ri = i;
+
+    return *p;
+}
+
+void remove_read(rnode** p)
+{
+
+    if (*p != NULL) {
+        rnode* n = *p;
+        *p = (*p)->next;
+        free(n);
+    } else {
+        printf("Can't remove a NULL!\n");
+    }
+}
+
+rnode** search_read(rnode** n, unsigned int i)
+{
+
+    while (*n != NULL) {
+        /*    printf("found read %i\n", (*n)->ri);*/
+        if ((*n)->ri == i) return n;
+        n = &(*n)->next;
+    }
+
     return NULL;
-  
-  n->next = *p; // *p is a pointer (variable pointed by a double pointer)
-  *p = n;
-  n->ri = i;
-  
-  return *p;
 }
 
-void remove_read(rnode** p){
-  
-  if(*p != NULL){
-    rnode* n = *p;
-    *p = (*p)->next;
-    free(n);
-  }
-  else{
-    printf("Can't remove a NULL!\n");
-  }
-  
+void print_reads(rnode* n)
+{
+
+    if (n == NULL) printf("no reads in this list\n");
+
+    while (n != NULL) {
+        printf("print %p %p %d\n", (void*)n, (void*)n->next, n->ri);
+        n = n->next;
+    }
 }
 
-rnode** search_read(rnode** n, unsigned int i){
-  
-  while(*n != NULL){
-    /*    printf("found read %i\n", (*n)->ri);*/
-    if((*n)->ri == i)
-      return n;
-    n = &(*n)->next;
-  }
-  
-  return NULL;
-}
-
-void print_reads(rnode* n){
-  
-  if(n == NULL)
-    printf("no reads in this list\n");
-
-  while (n!= NULL){
-    printf("print %p %p %d\n", (void*)n, (void*)n->next, n->ri);
-    n = n->next;
-  }
-  
-}
-
-typedef struct hns {
-  /** **********************
+typedef struct hns
+{
+    /** **********************
       haplotype node structure
       records all sampled haplotypes
       ********************** */
-  unsigned int hi;
-  unsigned int step;
-  unsigned int count;
-  unsigned short int* h;
-  struct hns* next;
-  struct hns* pred;
+    unsigned int hi;
+    unsigned int step;
+    unsigned int count;
+    unsigned short int* h;
+    struct hns* next;
+    struct hns* pred;
 } hnode;
 
-typedef struct hns_single {
-  //  unsigned int hi;
-  //  char* id;
-  //  unsigned int step;
-  unsigned short int count;
-  unsigned short int* h;
+typedef struct hns_single
+{
+    //  unsigned int hi;
+    //  char* id;
+    //  unsigned int step;
+    unsigned short int count;
+    unsigned short int* h;
 } hnode_single;
 
-hnode* add_hap(hnode** p, hnode* pred, unsigned int i, unsigned int J, unsigned int step) {
-  // node, index, size, theta, read_list, haplotype, read_dist
-  hnode* n = (hnode*)malloc(sizeof(hnode));
-  if(n == NULL)
-    return NULL;
-  
-  n->next = *p; // *p is a pointer (variable pointed by a double pointer)
-  *p = n;
-  
-  n->hi = i;
-  n->h = (unsigned short int*)malloc(J*sizeof(unsigned short int));
-  n->pred = pred;
-  n->step = step;
-  n->count = 0;
-  haplotypecount++;
-  return *p;
-}
+hnode* add_hap(hnode** p, hnode* pred, unsigned int i, unsigned int J, unsigned int step)
+{
+    // node, index, size, theta, read_list, haplotype, read_dist
+    hnode* n = (hnode*)malloc(sizeof(hnode));
+    if (n == NULL) return NULL;
 
+    n->next = *p;  // *p is a pointer (variable pointed by a double pointer)
+    *p = n;
+
+    n->hi = i;
+    n->h = (unsigned short int*)malloc(J * sizeof(unsigned short int));
+    n->pred = pred;
+    n->step = step;
+    n->count = 0;
+    haplotypecount++;
+    return *p;
+}
 
 /* void remove_hap(hnode **n) { */
 /*   (*n)->prev->next = (*n)->next; */
@@ -165,117 +165,116 @@ hnode* add_hap(hnode** p, hnode* pred, unsigned int i, unsigned int J, unsigned 
 /*   free(*n); */
 /* } */
 
-typedef struct cns {
-  /** *********************************************************
+typedef struct cns
+{
+    /** *********************************************************
       Components list structure:
       ci -> index of the component
       size -> component size (number of unique reads)
-      weight -> weighted component size (accounting for reads represented by 
+      weight -> weighted component size (accounting for reads represented by
                 each unique read)
       rlist -> points to the list of reads
       hh -> points to the list of haplotypes
       h -> haplotype sequence
-      rd0 -> points to a vector storing hamming distances between h and all 
+      rd0 -> points to a vector storing hamming distances between h and all
              unique reads
       rd1 -> points to a vector storing similarities between h and all unique
              reads
       next -> next node
       ********************************************************** */
-  unsigned int ci;
-  unsigned int size;
-  unsigned int weight; 
-  struct rns* rlist;
-  struct hns* hh;
-  unsigned short int* h;
-  unsigned short int* rd0;
-  unsigned short int* rd1;
-  unsigned int step;
-  struct cns* next;
+    unsigned int ci;
+    unsigned int size;
+    unsigned int weight;
+    struct rns* rlist;
+    struct hns* hh;
+    unsigned short int* h;
+    unsigned short int* rd0;
+    unsigned short int* rd1;
+    unsigned int step;
+    struct cns* next;
 } cnode;
 
 cnode* add_comp(cnode** p, hnode** phst, unsigned int i, int s, struct rns* rl,
-		unsigned short int* th, unsigned short int* rd0, unsigned short int* rd1,
-		unsigned int J,unsigned int step, unsigned int recordflag) {
-  // node, index, size, theta, read_list, haplotype, read_dist
-  cnode* n = (cnode*)malloc(sizeof(cnode));
-  
-  if(n == NULL)
+                unsigned short int* th, unsigned short int* rd0, unsigned short int* rd1,
+                unsigned int J, unsigned int step, unsigned int recordflag)
+{
+    // node, index, size, theta, read_list, haplotype, read_dist
+    cnode* n = (cnode*)malloc(sizeof(cnode));
+
+    if (n == NULL) return NULL;
+
+    n->next = *p;  // *p is a pointer (variable pointed by a double pointer)
+    *p = n;
+    n->ci = i;
+    n->size = s;
+    n->rlist = rl;
+    n->rd0 = rd0;
+    n->rd1 = rd1;
+    n->h = th;
+    n->step = step;
+
+    if (recordflag) {
+        add_hap(phst, NULL, i, J, step);
+        n->hh = *phst;
+    } else {
+        n->hh = NULL;
+    }
+
+    return *p;
+}
+
+void remove_comp(cnode** p)
+{
+
+    if (*p != NULL) {
+        cnode* n = *p;
+        *p = (*p)->next;
+        free(n->rlist);
+        free(n->h);
+        free(n->rd0);
+        free(n->rd1);
+        free(n);
+    }
+}
+
+cnode** search_comp(cnode** n, unsigned int i)
+{
+
+    while (*n != NULL) {
+        if ((*n)->ci == i) return n;
+        n = &(*n)->next;
+    }
+
     return NULL;
-  
-  n->next = *p; // *p is a pointer (variable pointed by a double pointer)
-  *p = n;
-  n->ci = i;
-  n->size = s;
-  n->rlist = rl;
-  n->rd0 = rd0;
-  n->rd1 = rd1;
-  n->h = th;
-  n->step = step;
-  
-  if(recordflag){
-    add_hap(phst, NULL, i, J, step);
-    n->hh = *phst;
-  }else{
-    n->hh = NULL;
-  }
-  
-  return *p;
 }
 
+void print_comp(cnode* n)
+{
 
-void remove_comp(cnode** p){
-  
-  if(*p != NULL){
-    cnode* n = *p;
-    *p = (*p)->next;
-    free(n->rlist);
-    free(n->h);
-    free(n->rd0);
-    free(n->rd1);
-    free(n);
-  }
+    if (n == NULL) printf("no reads in this list\n");
 
-}
-
-cnode** search_comp(cnode** n, unsigned int i){
-  
-  while(*n != NULL){
-    if((*n)->ci == i)
-      return n;
-    n = &(*n)->next;
-  }
-  
-  return NULL;
-}
-
-void print_comp(cnode* n){
-  
-  if( n == NULL)
-    printf("no reads in this list\n");
-
-  while (n != NULL){
-    printf("print %p %p %d\n", (void*)n, (void*)n->next, n->ci);
-    n = n->next;
-  }
-  
+    while (n != NULL) {
+        printf("print %p %p %d\n", (void*)n, (void*)n->next, n->ci);
+        n = n->next;
+    }
 }
 /*
 void print_stats(std::ofstream& out_file, const cnode* cn, unsigned int J){
-  
+
   unsigned int i, j;
   rnode* p;
   out_file << "# -------- PRINTING STATS ---------\n";
   if( cn == NULL)
     out_file << "# no components in this list\n";
-  
+
   while (cn != NULL){
-    
+
     i=0;
     p = cn->rlist;
-    
+
     if(p == NULL)
       out_file << "# no reads in this component\n";
-    
+
 #ifdef DEBUG
     if(p != NULL)
       out_file << "# reads in the list:\t";
@@ -285,69 +284,66 @@ void print_stats(std::ofstream& out_file, const cnode* cn, unsigned int J){
       i++;
       p = p->next;
     }
-    
-    out_file << "\n# component " << cn->ci << " at " << (void*)cn << " has " << i << " reads size= " << cn->size <<"\n";
+
+    out_file << "\n# component " << cn->ci << " at " << (void*)cn << " has " << i << " reads size= "
+<< cn->size <<"\n";
     out_file << "# haplotype is:\n# >h" << cn->ci <<"\n# ";
     for(j=0; j<J; j++)
       out_file << i2dna_code[cn->h[j]];
     out_file << "\n\n";
 
     cn = cn->next;
-    
+
   }
-  out_file << "# -------- STATS PRINTED ----------\n"; 
+  out_file << "# -------- STATS PRINTED ----------\n";
 }
 */
 
-void move_read(unsigned int i, cnode** from, cnode** to){
-  //! move reads indexed by i from a node to another
-  rnode* rn;
-  rnode* tmp;
-  rnode* tmp2;
-  
-  if((*from)->rlist->ri == i){ // if read is the head node
-    //    printf("moving, was in the head\n");
-    tmp = (*to)->rlist;
-    tmp2 = (*from)->rlist->next;
-    (*to)->rlist = (*from)->rlist;
-    (*to)->rlist->next = tmp;
-    (*from)->rlist = tmp2;
-  }
-  
-  else{
-    //    printf("moving, not in the head\n");
-    rn = (*from)->rlist;
+void move_read(unsigned int i, cnode** from, cnode** to)
+{
+    //! move reads indexed by i from a node to another
+    rnode* rn;
+    rnode* tmp;
+    rnode* tmp2;
 
-    while(rn->next != NULL){
-      
-      if(rn->next->ri == i){
-        tmp = rn->next;
-        rn->next = rn->next->next;
-        
-        tmp2 = (*to)->rlist;
-        (*to)->rlist = tmp;
-        (*to)->rlist->next = tmp2;
-	
-        break;
-      }
-      
-      rn = rn->next;
-      
+    if ((*from)->rlist->ri == i) {  // if read is the head node
+        //    printf("moving, was in the head\n");
+        tmp = (*to)->rlist;
+        tmp2 = (*from)->rlist->next;
+        (*to)->rlist = (*from)->rlist;
+        (*to)->rlist->next = tmp;
+        (*from)->rlist = tmp2;
     }
 
-  }
+    else {
+        //    printf("moving, not in the head\n");
+        rn = (*from)->rlist;
 
+        while (rn->next != NULL) {
+
+            if (rn->next->ri == i) {
+                tmp = rn->next;
+                rn->next = rn->next->next;
+
+                tmp2 = (*to)->rlist;
+                (*to)->rlist = tmp;
+                (*to)->rlist->next = tmp2;
+
+                break;
+            }
+
+            rn = rn->next;
+        }
+    }
 }
 
-
-
-typedef struct sss {
-/** **************************
+typedef struct sss
+{
+    /** **************************
     sampstat structures
     ************************** */
 
-  unsigned int untouched;
-  unsigned int proposed;
-  struct cns* to_class;
+    unsigned int untouched;
+    unsigned int proposed;
+    struct cns* to_class;
 } ssret;
-

--- a/src/shorah/data_structures.hpp
+++ b/src/shorah/data_structures.hpp
@@ -29,8 +29,7 @@
     linked list definitions
     and functions
 */
-// using std::map;
-// using std::string;
+
 static char i2dna_code[] = "ACGT-N";
 
 unsigned int haplotypecount = 0;

--- a/src/shorah/dpm_sampler.cpp
+++ b/src/shorah/dpm_sampler.cpp
@@ -23,15 +23,15 @@
 # along with ShoRAH.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <float.h>
-#include <math.h>
 #include <nmmintrin.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
 #include <unistd.h>
 #include <algorithm>
+#include <cfloat>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -47,7 +47,6 @@
 #include <gsl/gsl_sf_log.h>
 #include <gsl/gsl_sf_pow_int.h>
 
-using namespace std;
 #include "data_structures.hpp"
 #include "dpm_sampler.hpp"
 
@@ -72,22 +71,22 @@ int main(int argc, char** argv)
     double_threshold_max = gsl_sf_log(DBL_MAX);
     parsecommandline(argc, argv);
 
-    string instr = filein;
+    std::string instr = filein;
 
     /// rename sampling file and debug file
     int insize = instr.find('.');
-    string statstr = instr.substr(0, insize).append(".dbg");
-    string outstr = instr.substr(0, insize).append(".smp");
-    string alphastr = instr.substr(0, insize).append(".alpha");
-    string iterstr = instr.substr(0, insize).append(".iter");
+    std::string statstr = instr.substr(0, insize).append(".dbg");
+    std::string outstr = instr.substr(0, insize).append(".smp");
+    std::string alphastr = instr.substr(0, insize).append(".alpha");
+    std::string iterstr = instr.substr(0, insize).append(".iter");
 
-    ofstream out_file(outstr.c_str());
-    ofstream stat_file(statstr.c_str());
+    std::ofstream out_file(outstr.c_str());
+    std::ofstream stat_file(statstr.c_str());
 
-    stat_file << "# dna_code:\t" << i2dna_code << endl;
+    stat_file << "# dna_code:\t" << i2dna_code << std::endl;
 
     //  randseed = 1257501510;
-    stat_file << "# randseed = " << randseed << endl;
+    stat_file << "# randseed = " << randseed << std::endl;
 
     // random number generator via gsl
     gsl_rng_env_setup();
@@ -132,9 +131,9 @@ int main(int argc, char** argv)
         //  ftable[j][i] = ftable[j][i]/tot_pos;
         //}
     }
-    stat_file << "# Number of reads, n = " << n << endl;
-    stat_file << "# Read length, J = " << J << endl;
-    stat_file << "# J/10 + 1 = " << J / 10 + 1 << endl << endl;
+    stat_file << "# Number of reads, n = " << n << std::endl;
+    stat_file << "# Read length, J = " << J << std::endl;
+    stat_file << "# J/10 + 1 = " << J / 10 + 1 << std::endl << std::endl;
 
     // creads = (int**)calloc(n, sizeof(int*));
 
@@ -152,14 +151,14 @@ int main(int argc, char** argv)
         readtable[i]->weight = 1;  // mapped = no
     }
 
-    // multimap<string,int>::iterator it;
-    // string stemp = ("");
+    // std::multimap<std::string,int>::iterator it;
+    // std::string stemp = ("");
     // int mapcount, mflag;
     /*
   for(j=0; j<J/10 + 1; j++)
     stemp += static_cast<ostringstream*>( &(ostringstream() << readtable[0]->creads[j]) )->str();
 
-  readmap.insert ( pair<string,int>(stemp, 1) );
+  readmap.insert ( std::pair<std::string,int>(stemp, 1) );
   readtable[0]->mindex = 0;
 
 
@@ -178,21 +177,21 @@ int main(int argc, char** argv)
       }
     }
     if(mflag == 0){
-      readmap.insert ( pair<string,int>(stemp, 1) );
+      readmap.insert ( std::pair<std::string,int>(stemp, 1) );
       readtable[i]->mindex = mapcount;
       }
   }
   */
 
     // Tuple for storing hamming distance
-    pair<int, int> hd;
+    std::pair<int, int> hd;
 
     for (i = 0; i < n; i++) {
         if (readtable[i]->weight > 0) {  // only if read i has not been mapped to a previous read
             readtable[i]->mindex = i;    // then it is unique
             for (j = i + 1; j < n; j++) {
                 if (readtable[i]->weight >= LIMIT) {
-                    stat_file << "# LIMIT reached!" << endl;
+                    stat_file << "# LIMIT reached!" << std::endl;
                     break;
                 }
 
@@ -217,8 +216,9 @@ int main(int argc, char** argv)
 
   for(i=0; i<n; i++){
     hd = seq_distance_rr(readtable[i]->creads, readtable[readtable[i]->mindex], J);
-    cout<<" Read "<<i<<" is mapped to "<<readtable[i]->mindex<<" with distance = "<<hd[0]<<" and has
-  weight = "<<readtable[i]->weight<<endl;
+    std::std::cout<<" Read "<<i<<" is mapped to "<<readtable[i]->mindex<<" with distance =
+  "<<hd[0]<<" and has
+  weight = "<<readtable[i]->weight<<std::endl;
   }
   */
     // q = readmap.size();
@@ -228,7 +228,7 @@ int main(int argc, char** argv)
         if (readtable[i]->weight > 0) q++;
     }
 
-    stat_file << "# q = " << q << endl;
+    stat_file << "# q = " << q << std::endl;
 
     readtable2 = (crnode**)calloc(q, sizeof(crnode*));
 
@@ -276,15 +276,15 @@ int main(int argc, char** argv)
     delete[] itrack;
     build_assignment(stat_file);
 
-    stat_file << "# Assignment built" << endl;
+    stat_file << "# Assignment built" << std::endl;
 
     stat_file << "# +++++++++++++++++++ BEFORE THE SAMPLING +++++++++++++++++++\n";
     //  print_stats(out_file, mxt, J);
-    out_file << setw(6) << "#iter";
-    out_file << setw(8) << "class";
-    out_file << setw(8) << "untouch";
-    out_file << setw(9) << "theta";
-    out_file << setw(9) << "gamma\n";
+    out_file << std::setw(6) << "#iter";
+    out_file << std::setw(8) << "class";
+    out_file << std::setw(8) << "untouch";
+    out_file << std::setw(9) << "theta";
+    out_file << std::setw(9) << "gamma\n";
 
     /*********************
     sampling procedure
@@ -316,7 +316,7 @@ int main(int argc, char** argv)
             if (iter != iter2 and iter2 > k + 100) {
                 if (iter2 < iter) {
                     HISTORY = iter2 - k - 1;
-                    cerr << "HISTORY just changed to " << HISTORY << endl;
+                    std::cerr << "HISTORY just changed to " << HISTORY << std::endl;
                 }
                 iter = iter2;
             }
@@ -394,25 +394,26 @@ int main(int argc, char** argv)
 // sample_ref();    // sampling the reference every step gives strange behaviour...
 
 #ifdef DEBUG
-        cerr << "dt=" << dt << "\ttheta=" << theta << "\tgamma=" << gam << endl;
+        std::cerr << "dt=" << dt << "\ttheta=" << theta << "\tgamma=" << gam << std::endl;
 #endif
         //    out_file("iteration\t%i\t%i\t%i\t%f\t%f\n", k+1, count_classes(mxt), tot_untouch,
         //    theta, gam);
-        out_file << setw(6) << k + 1;               // << "\t";
-        out_file << setw(8) << count_classes(mxt);  // << "\t";
-        out_file << setw(8) << tot_untouch;         // << "\t";
-        out_file << setw(10) << setprecision(6) << theta << setw(10) << gam << endl;
+        out_file << std::setw(6) << k + 1;               // << "\t";
+        out_file << std::setw(8) << count_classes(mxt);  // << "\t";
+        out_file << std::setw(8) << tot_untouch;         // << "\t";
+        out_file << std::setw(10) << std::setprecision(6) << theta << std::setw(10) << gam
+                 << std::endl;
     }
 
     if (remove(iterstr.c_str()) != 0)
-        stat_file << "# iter file was not created" << endl;
+        stat_file << "# iter file was not created" << std::endl;
     else
-        stat_file << "# iter file successfully deleted" << endl;
+        stat_file << "# iter file successfully deleted" << std::endl;
 
     if (remove(alphastr.c_str()) != 0)
-        stat_file << "# alpha file was not created" << endl;
+        stat_file << "# alpha file was not created" << std::endl;
     else
-        stat_file << "# alpha file successfully deleted" << endl;
+        stat_file << "# alpha file successfully deleted" << std::endl;
 
     (void)time(&t2);
 
@@ -420,7 +421,7 @@ int main(int argc, char** argv)
       sampling ends
   *********************/
 
-    stat_file << "# Survived sampling" << endl;
+    stat_file << "# Survived sampling" << std::endl;
     stat_file << "# sampling took " << difftime(t2, t1) << " seconds\n";
 
     //  write_assignment(k, new_proposed, mxt);
@@ -431,11 +432,11 @@ int main(int argc, char** argv)
     for (j = 0; j < J; j++)
         stat_file << i2dna_code[h[j]];
     stat_file << "\n\n\n";
-    stat_file << "\n#gamma = " << gam << endl;
-    stat_file << "\n#theta = " << theta << endl;
+    stat_file << "\n#gamma = " << gam << std::endl;
+    stat_file << "\n#theta = " << theta << std::endl;
     stat_file << "\n#final number of components = " << K1 << "\n";
     stat_file << "\n#made " << new_proposed << " new clusters\n";
-    stat_file << "\n#number of haplotypes in history = " << haplotypecount << endl;
+    stat_file << "\n#number of haplotypes in history = " << haplotypecount << std::endl;
 
     /******************
     write corrected
@@ -470,7 +471,7 @@ int main(int argc, char** argv)
 
     cleanup();
     (void)time(&t1);
-    stat_file << "# after sampling took " << difftime(t1, t2) << " seconds" << endl;
+    stat_file << "# after sampling took " << difftime(t1, t2) << " seconds" << std::endl;
     /*
   tn = mxt;
   cnode* tn2;
@@ -478,32 +479,33 @@ int main(int argc, char** argv)
 
   while(tn != NULL){
     tr = tn->rlist;
-    cout<<tn->ci<<endl;
+    std::cout<<tn->ci<<std::endl;
     while(tr != NULL){
       for(it=0; it < readtable2[tr->ri]->weight; it++)
-    cout<<readtable2[tr->ri]->mindices[it]<<"   ";
-      cout<<"   "<<tr->ri<<"  weight = "<<readtable2[tr->ri]->weight<<"   "<<tn->rd0[tr->ri]<<"  ";
+    std::cout<<readtable2[tr->ri]->mindices[it]<<"   ";
+      std::cout<<"   "<<tr->ri<<"  weight = "<<readtable2[tr->ri]->weight<<"   "<<tn->rd0[tr->ri]<<"
+  ";
       // if(tn->rd0[tr->ri] >= 0){
       tn2 = mxt;
       while(tn2 != NULL){
-    cout<<"distance to "<<tn2->ci<<" = "<<tn2->rd0[tr->ri]<<"   ";
+    std::cout<<"distance to "<<tn2->ci<<" = "<<tn2->rd0[tr->ri]<<"   ";
     tn2 = tn2->next;
       }
     // }
-      cout<<endl;
+      std::cout<<std::endl;
       difference += tn->rd0[tr->ri];
       similarity += tn->rd1[tr->ri];
       alt_diff += tn->rd0[tr->ri] * readtable2[tr->ri]->weight;
       alt_sim += tn->rd1[tr->ri] * readtable2[tr->ri]->weight;
       tr = tr->next;
     }
-    cout<<" total weight = "<<weight(tn)<<endl;
+    std::cout<<" total weight = "<<weight(tn)<<std::endl;
     tn = tn->next;
   }
 
-  cout<<"difference = "<<difference<<"\tsimilarity = "<<similarity<<endl;
-  cout<<"alt_diff = "<<alt_diff<<"\talt_sim = "<<alt_sim<<endl;
-  cout<<"\ttotbases = "<<totbases<<"\tq * J = "<<q * J<<endl;
+  std::cout<<"difference = "<<difference<<"\tsimilarity = "<<similarity<<std::endl;
+  std::cout<<"alt_diff = "<<alt_diff<<"\talt_sim = "<<alt_sim<<std::endl;
+  std::cout<<"\ttotbases = "<<totbases<<"\tq * J = "<<q * J<<std::endl;
   */
     delete[] temp;
     return 0;
@@ -539,7 +541,7 @@ void read_data(char* filename, std::ofstream& out_file)
     }
 
     if (n == 0) {
-        cout << "Error: No data found!\n";
+        std::cout << "Error: No data found!\n";
         exit(EXIT_FAILURE);
     }
 
@@ -730,7 +732,7 @@ void build_assignment(std::ofstream& out_file)
 
     // make the class list of K (or q?) initial components
 
-    out_file << "# Initial number of clusters, K = " << K << endl;
+    out_file << "# Initial number of clusters, K = " << K << std::endl;
 
     // create a linked list storing clusters/components/classes.
     // nodes are of type cnode's.
@@ -1068,7 +1070,7 @@ void sample_hap(cnode* cn)
                     if (log_pbase[i] < double_threshold_min) {
                         pbase[i] = 0.0;
                     } else {
-                        // cout<<"log_pbase["<<i<<"] = "<<log_pbase[i]<<endl;
+                        // std::cout<<"log_pbase["<<i<<"] = "<<log_pbase[i]<<std::endl;
                         pbase[i] = gsl_sf_exp(log_pbase[i]);
                     }
                 }
@@ -1127,7 +1129,7 @@ void sample_hap(cnode* cn)
 void check_size(const cnode* cst, unsigned int n)
 {
     unsigned int this_n = 0;
-    ofstream err_file("error_size.log");
+    std::ofstream err_file("error_size.log");
     while (cst != NULL) {
         this_n += cst->size;
         cst = cst->next;
@@ -1189,7 +1191,7 @@ std::pair<int, int> seq_distance_new(int* A, crnode* B, int seq_length)
    *             A[i] == B[i] == 'N', it counts as match. SECOND ENTRY OF
    *             RETURNED PAIR corresponds to the similarity.
    */
-    pair<int, int> dist;
+    std::pair<int, int> dist;
 
     for (int i = 0; i < seq_length / 10 + 1; ++i) {
         int X = *(A + i) ^ B->creads[i];
@@ -1220,7 +1222,7 @@ std::pair<int, int> seq_distance_rr(int* A, crnode* B, int seq_length)
    * Tends to be on the conservative side, as ambiguous matches (i.e., N-to-any,
    * but not N-to-N) are considered as mismatches.
    */
-    pair<int, int> dist;
+    std::pair<int, int> dist;
 
     for (int i = 0; i < seq_length / 10 + 1; ++i) {
         int X = *(A + i) ^ B->creads[i];
@@ -1256,7 +1258,7 @@ std::pair<int, int> seq_distance(unsigned short int* a, unsigned short int* b, i
    *             PAIR corresponds to the similarity.
    */
     int ns = 0;
-    pair<int, int> dist;
+    std::pair<int, int> dist;
 
     for (int i = 0; i < seq_length; ++i, ++a, ++b) {
         if (*a != B && *b != B) {
@@ -1276,7 +1278,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
   ******************************************/
     unsigned int dist, nodist, removed = 0, sz, ll;
     unsigned int tw;
-    pair<int, int> p;
+    std::pair<int, int> p;
 //  int local_ci;
 #ifdef DEBUG
     unsigned int j;
@@ -1301,7 +1303,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
     printf("-----------> sampling class for %ith read <----------\n", i);
     printf("---------------------------------------------------\n");
     //  printf("------------ c_ptr = %p with size = %d\n", c_ptr[i], c_ptr[i]->size);
-    cout << "----------- mxt here is " << mxt << "---------------------" << endl;
+    std::cout << "----------- mxt here is " << mxt << "---------------------" << std::endl;
 //  printf("------------- NOW STATS----------\n");
 //  print_stats(out_file, mxt, J);
 #endif
@@ -1365,11 +1367,11 @@ ssret* sample_class(unsigned int i, unsigned int step)
     b2 = (1. - theta) / ((double)B - 1.);
 
     if (theta == 0.0) {
-        cerr << "# There is something wrong wih THETA! ( == 0.0 )" << endl;
+        std::cerr << "# There is something wrong wih THETA! ( == 0.0 )" << std::endl;
         exit(EXIT_FAILURE);
     }
     if (gam == 0.0) {
-        cerr << "# There is something wrong with GAMMA! ( == 0.0 )" << endl;
+        std::cerr << "# There is something wrong with GAMMA! ( == 0.0 )" << std::endl;
         exit(EXIT_FAILURE);
     }
 
@@ -1392,7 +1394,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
             if (sz == 0) {
                 // This component should have been removed previously, because only
                 // consists of read i
-                cerr << "# Size of component " << cn->ci << " is zero" << endl;
+                std::cerr << "# Size of component " << cn->ci << " is zero" << std::endl;
                 exit(EXIT_FAILURE);
             }
             cl_ptr[st] = cn;
@@ -1406,7 +1408,8 @@ ssret* sample_class(unsigned int i, unsigned int step)
             if (tw == 0) {
                 // This component should have been removed previously, because only
                 // consists of read i
-                cerr << " # Weighted size of component " << cn->ci << "cannot be zero" << endl;
+                std::cerr << " # Weighted size of component " << cn->ci << "cannot be zero"
+                          << std::endl;
                 exit(EXIT_FAILURE);
             }
 
@@ -1428,7 +1431,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
                 }
             }
         } else {
-            cerr << "------********* CN->SIZE = 0 **********----------\n";
+            std::cerr << "------********* CN->SIZE = 0 **********----------\n";
             P[st] = 0.0;  // all prob, which shouldn't change, set to 0
         }
 
@@ -1461,7 +1464,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
     }
     cl_ptr[st] = NULL;
 
-    max_log_P = *max_element(log_P, log_P + st);  //! renormalization
+    max_log_P = *std::max_element(log_P, log_P + st);  //! renormalization
     //  min_log_P = *min_element(log_P, log_P+st); //! renormalization
 
     if (max_log_P >= 0)
@@ -1726,7 +1729,7 @@ void record_conf(cnode* tn, unsigned int step)
     char* ca;
     ca = (char*)calloc(J, sizeof(char*));
     i2dna_string(ca, tn->h, J);
-    string h = (string)ca;
+    std::string h = (std::string)ca;
     free(ca);
     freq_map::iterator freq_iter;
     ++support[h];  //! support is updated
@@ -1881,33 +1884,34 @@ struct invcomp
     bool operator()(int i1, int i2) const { return i1 > i2; }
 };
 
-void write_posterior_files(string instr)
+void write_posterior_files(std::string instr)
 {
     /** All the posterior information is written here
    */
-    //  cout << "HISTORY = " << HISTORY << endl;
+    //  std::cout << "HISTORY = " << HISTORY << std::endl;
     int insize = instr.rfind('.');
-    string corstr = instr.substr(0, insize).append("-cor.fas");
-    string supstr = instr.substr(0, insize).append("-support.fas");
-    string freqstr = instr.substr(0, insize).append("-freq.csv");
-    string str2;
+    std::string corstr = instr.substr(0, insize).append("-cor.fas");
+    std::string supstr = instr.substr(0, insize).append("-support.fas");
+    std::string freqstr = instr.substr(0, insize).append("-freq.csv");
+    std::string str2;
     int i = 0, rcount = 0, wcount = 0;
     float mean_freq, supp_fract;
     //  float supp_thresh = 0.5;
 
-    ofstream cor_file(corstr.c_str());
-    ofstream supp_file(supstr.c_str());
-    ofstream freq_file(freqstr.c_str());
+    std::ofstream cor_file(corstr.c_str());
+    std::ofstream supp_file(supstr.c_str());
+    std::ofstream freq_file(freqstr.c_str());
 
     sup_map::iterator si;
-    multimap<int, string, invcomp> rev_sup;  //! use a multimap to sort by value the support map
-    multimap<int, string, invcomp>::iterator ri;
+    std::multimap<int, std::string, invcomp>
+        rev_sup;  //! use a multimap to sort by value the support map
+    std::multimap<int, std::string, invcomp>::iterator ri;
 
     for (si = support.begin(); si != support.end(); ++si)
-        rev_sup.insert(pair<int, string>(si->second, si->first));
+        rev_sup.insert(std::pair<int, std::string>(si->second, si->first));
 
     // header of freq_file
-    freq_file << setfill('0');
+    freq_file << std::setfill('0');
     freq_file << "#haplotype\tsupport";
     for (unsigned int k = 0; k < HISTORY; k++)
         freq_file << "\treads";
@@ -1926,7 +1930,7 @@ void write_posterior_files(string instr)
                       << "posterior=" << supp_fract << " ave_reads=" << mean_freq << "\n";
             supp_file << ri->second << "\n";
 
-            freq_file << ">hap_" << setw(5) << i << "\t" << ri->first;
+            freq_file << ">hap_" << std::setw(5) << i << "\t" << ri->first;
             for (unsigned int k = 0; k < HISTORY; k++)
                 freq_file << "\t" << freq[ri->second][k];
             freq_file << "\n";
@@ -1937,7 +1941,7 @@ void write_posterior_files(string instr)
     for (unsigned int readi = 0; readi < q; readi++) {
         rev_sup.clear();  // reuse the multimap
         for (si = read2hap[readi].begin(); si != read2hap[readi].end(); ++si)
-            rev_sup.insert(pair<int, string>(si->second, si->first));
+            rev_sup.insert(std::pair<int, std::string>(si->second, si->first));
 
         ri = rev_sup.begin();
         for (wcount = 0; wcount < readtable2[readi]->weight; wcount++) {
@@ -1955,7 +1959,7 @@ double setfinalhaplotype(unsigned int i)
 {
     unsigned int j, k;
     int hap;  // last haplotype
-    pair<int, int> p;
+    std::pair<int, int> p;
     double quality;
 
     // sort lexicographically the haplotypes

--- a/src/shorah/dpm_sampler.cpp
+++ b/src/shorah/dpm_sampler.cpp
@@ -23,7 +23,6 @@
 # along with ShoRAH.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <nmmintrin.h>
 #include <unistd.h>
 #include <algorithm>
 #include <cfloat>
@@ -40,6 +39,10 @@
 #include <new>
 #include <sstream>
 #include <string>
+
+#ifdef HAVE_POPCNT
+#include <nmmintrin.h>
+#endif
 
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>

--- a/src/shorah/dpm_sampler.cpp
+++ b/src/shorah/dpm_sampler.cpp
@@ -23,146 +23,146 @@
 # along with ShoRAH.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <float.h>
+#include <math.h>
+#include <nmmintrin.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
-#include <unistd.h>
-#include <float.h>
 #include <time.h>
-#include <map>
-#include <string>
-#include <iostream>
-#include <iomanip>
-#include <fstream>
-#include <new>
-#include <memory>
-#include <sstream>
+#include <unistd.h>
 #include <algorithm>
-#include <nmmintrin.h>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <new>
+#include <sstream>
+#include <string>
 
-#include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
-#include <gsl/gsl_sf_pow_int.h>
-#include <gsl/gsl_sf_log.h>
+#include <gsl/gsl_rng.h>
 #include <gsl/gsl_sf_exp.h>
+#include <gsl/gsl_sf_log.h>
+#include <gsl/gsl_sf_pow_int.h>
 
 using namespace std;
 #include "data_structures.hpp"
 #include "dpm_sampler.hpp"
 
 #define PROPHISTSIZE 100
-int main(int argc, char** argv){
-  
-  unsigned int i, j, k, ll, K1=0, iter2, tot_untouch, new_proposed=0;
-  int dk1, hapbases;
-  pair<int,int> p;
-  cnode* tn;
-  //rnode* rn;
-  rnode* tr;
-  ssret* samp_stat;
-  double dt;
-  time_t t1, t2;
-  FILE* alphafile;
-  FILE* iterfile;
-  float alpha2;
-  
-  double_threshold_min = gsl_sf_log(DBL_MIN);
-  double_threshold_max = gsl_sf_log(DBL_MAX);
-  parsecommandline(argc, argv);
-  
-  string instr = filein;
+int main(int argc, char** argv)
+{
 
-  /// rename sampling file and debug file  
-  int insize = instr.find('.');
-  string statstr = instr.substr(0,insize).append(".dbg");
-  string outstr = instr.substr(0,insize).append(".smp");
-  string alphastr = instr.substr(0,insize).append(".alpha");
-  string iterstr = instr.substr(0,insize).append(".iter");
-  
-  ofstream out_file(outstr.c_str());
-  ofstream stat_file(statstr.c_str());
-  
-  stat_file << "# dna_code:\t" << i2dna_code << endl;
-  
-  //  randseed = 1257501510;
-  stat_file << "# randseed = " << randseed << endl;
-  
-  // random number generator via gsl
-  gsl_rng_env_setup();
-  T = gsl_rng_default;
-  rg = gsl_rng_alloc(T);
-  gsl_rng_set(rg, randseed);
-  
-  res_dist = (int*)calloc(2, sizeof(int));
-  if (res_dist == NULL) exit(EXIT_FAILURE);
-  res = (ssret*)malloc(sizeof(ssret));
-  if (res == NULL) exit(EXIT_FAILURE);
-  
-  cbase = (int*) malloc(B * sizeof(int)); // count base
-  if (cbase == NULL) exit(EXIT_FAILURE);
-  pbase = (double*) malloc(B * sizeof(double));
-  if (pbase == NULL) exit(EXIT_FAILURE);
-  log_pbase = (double*) malloc(B * sizeof(double)); 
-  if (log_pbase == NULL) exit(EXIT_FAILURE);
+    unsigned int i, j, k, ll, K1 = 0, iter2, tot_untouch, new_proposed = 0;
+    int dk1, hapbases;
+    std::pair<int, int> p;
+    cnode* tn;
+    // rnode* rn;
+    rnode* tr;
+    ssret* samp_stat;
+    double dt;
+    time_t t1, t2;
+    FILE* alphafile;
+    FILE* iterfile;
+    float alpha2;
 
-  read_data(filein, stat_file);
-  ftable = (int**) calloc(J, sizeof(int*));
-  ftable_sum = new int[J];
+    double_threshold_min = gsl_sf_log(DBL_MIN);
+    double_threshold_max = gsl_sf_log(DBL_MAX);
+    parsecommandline(argc, argv);
 
-  //int tot_pos;
+    string instr = filein;
 
-  for(j=0; j<J; j++){
-    ftable[j] = new int[B];
-    for(i=0; i<B; i++)
-      ftable[j][i] = 0;
-  }
- 
-  for (j=0; j<J; j++){
-    ftable_sum[j] = 0;
-    //ftable[j][i] = 0.0;
-    for (k =0; k<n; k++){
-      if(r[k][j] < B){
-	    ftable[j][r[k][j]] ++;
-	    ftable_sum[j]++;
-      }
+    /// rename sampling file and debug file
+    int insize = instr.find('.');
+    string statstr = instr.substr(0, insize).append(".dbg");
+    string outstr = instr.substr(0, insize).append(".smp");
+    string alphastr = instr.substr(0, insize).append(".alpha");
+    string iterstr = instr.substr(0, insize).append(".iter");
+
+    ofstream out_file(outstr.c_str());
+    ofstream stat_file(statstr.c_str());
+
+    stat_file << "# dna_code:\t" << i2dna_code << endl;
+
+    //  randseed = 1257501510;
+    stat_file << "# randseed = " << randseed << endl;
+
+    // random number generator via gsl
+    gsl_rng_env_setup();
+    T = gsl_rng_default;
+    rg = gsl_rng_alloc(T);
+    gsl_rng_set(rg, randseed);
+
+    res_dist = (int*)calloc(2, sizeof(int));
+    if (res_dist == NULL) exit(EXIT_FAILURE);
+    res = (ssret*)malloc(sizeof(ssret));
+    if (res == NULL) exit(EXIT_FAILURE);
+
+    cbase = (int*)malloc(B * sizeof(int));  // count base
+    if (cbase == NULL) exit(EXIT_FAILURE);
+    pbase = (double*)malloc(B * sizeof(double));
+    if (pbase == NULL) exit(EXIT_FAILURE);
+    log_pbase = (double*)malloc(B * sizeof(double));
+    if (log_pbase == NULL) exit(EXIT_FAILURE);
+
+    read_data(filein, stat_file);
+    ftable = (int**)calloc(J, sizeof(int*));
+    ftable_sum = new int[J];
+
+    // int tot_pos;
+
+    for (j = 0; j < J; j++) {
+        ftable[j] = new int[B];
+        for (i = 0; i < B; i++)
+            ftable[j][i] = 0;
     }
-    //for (i=0;i<B; i++){
-    //  ftable[j][i] = ftable[j][i]/tot_pos;
-    //}  
-  }
-  stat_file << "# Number of reads, n = " << n << endl;
-  stat_file << "# Read length, J = " << J << endl; 
-  stat_file << "# J/10 + 1 = " << J/10 + 1 << endl << endl;
 
-  // creads = (int**)calloc(n, sizeof(int*));
+    for (j = 0; j < J; j++) {
+        ftable_sum[j] = 0;
+        // ftable[j][i] = 0.0;
+        for (k = 0; k < n; k++) {
+            if (r[k][j] < B) {
+                ftable[j][r[k][j]]++;
+                ftable_sum[j]++;
+            }
+        }
+        // for (i=0;i<B; i++){
+        //  ftable[j][i] = ftable[j][i]/tot_pos;
+        //}
+    }
+    stat_file << "# Number of reads, n = " << n << endl;
+    stat_file << "# Read length, J = " << J << endl;
+    stat_file << "# J/10 + 1 = " << J / 10 + 1 << endl << endl;
 
-  readtable = (crnode**)calloc(n, sizeof(crnode*));
+    // creads = (int**)calloc(n, sizeof(int*));
 
-  for(i=0; i<n; i++){
-    readtable[i] = (crnode*)calloc(1, sizeof(crnode));
-    readtable[i]->creads = new int[J/10 + 1];
-    readtable[i]->mindices = new int;      //instantiated, although not used
-  }
+    readtable = (crnode**)calloc(n, sizeof(crnode*));
 
-  for(i=0; i<n; i++){
-    read_conversion(readtable[i], r[i], J);
-    readtable[i]->mindex = 0;
-    readtable[i]->weight = 1; // mapped = no
-  }
+    for (i = 0; i < n; i++) {
+        readtable[i] = (crnode*)calloc(1, sizeof(crnode));
+        readtable[i]->creads = new int[J / 10 + 1];
+        readtable[i]->mindices = new int;  // instantiated, although not used
+    }
 
-   
-  //multimap<string,int>::iterator it;
-  //string stemp = ("");
-  //int mapcount, mflag;
-  /*
+    for (i = 0; i < n; i++) {
+        read_conversion(readtable[i], r[i], J);
+        readtable[i]->mindex = 0;
+        readtable[i]->weight = 1;  // mapped = no
+    }
+
+    // multimap<string,int>::iterator it;
+    // string stemp = ("");
+    // int mapcount, mflag;
+    /*
   for(j=0; j<J/10 + 1; j++)
     stemp += static_cast<ostringstream*>( &(ostringstream() << readtable[0]->creads[j]) )->str();
-  
+
   readmap.insert ( pair<string,int>(stemp, 1) );
   readtable[0]->mindex = 0;
-  
-  
+
+
   for(i=1; i<n; i++){
     stemp = ("");
     for(j=0; j<J/10 + 1; j++)
@@ -184,277 +184,271 @@ int main(int argc, char** argv){
   }
   */
 
-  // Tuple for storing hamming distance
-  pair<int,int> hd; 
+    // Tuple for storing hamming distance
+    pair<int, int> hd;
 
-  for(i=0; i<n; i++){
-    if(readtable[i]->weight > 0){         // only if read i has not been mapped to a previous read
-      readtable[i]->mindex = i;           // then it is unique
-      for(j=i+1; j<n; j++){
-        if(readtable[i]->weight >= LIMIT){
-          stat_file << "# LIMIT reached!" << endl;
-          break;
-        }
+    for (i = 0; i < n; i++) {
+        if (readtable[i]->weight > 0) {  // only if read i has not been mapped to a previous read
+            readtable[i]->mindex = i;    // then it is unique
+            for (j = i + 1; j < n; j++) {
+                if (readtable[i]->weight >= LIMIT) {
+                    stat_file << "# LIMIT reached!" << endl;
+                    break;
+                }
 
-        /* NOTE: hd is the hamming distance of string 'i' and 'j'. We only check 
-         * whether hd == 0, which is equivalent to strings being identical. The 
-         * same could be achieved using a lexicographic sort of the strings 
-         * followed by a linear scan in 0(n*long(n)). Actually, by using the 
-         * strings as keys for a STL hash_map, the whole problem can be 
+                /* NOTE: hd is the hamming distance of string 'i' and 'j'. We only check
+         * whether hd == 0, which is equivalent to strings being identical. The
+         * same could be achieved using a lexicographic sort of the strings
+         * followed by a linear scan in 0(n*long(n)). Actually, by using the
+         * strings as keys for a STL hash_map, the whole problem can be
          * solved in O(n).
          */
-        hd = seq_distance_rr(readtable[i]->creads, readtable[j], J);
-        if(hd.first == 0){
-	      readtable[j]->mindex = i;
-	      readtable[j]->weight = 0;       // not unique, mapped = yes
-	      readtable[i]->weight++;
-        } 
-      }
+                hd = seq_distance_rr(readtable[i]->creads, readtable[j], J);
+                if (hd.first == 0) {
+                    readtable[j]->mindex = i;
+                    readtable[j]->weight = 0;  // not unique, mapped = yes
+                    readtable[i]->weight++;
+                }
+            }
+        }
     }
-  }
-       
-  /*  
+
+    /*
 
   for(i=0; i<n; i++){
-    hd = seq_distance_rr(readtable[i]->creads, readtable[readtable[i]->mindex], J); 
-    cout<<" Read "<<i<<" is mapped to "<<readtable[i]->mindex<<" with distance = "<<hd[0]<<" and has weight = "<<readtable[i]->weight<<endl;
+    hd = seq_distance_rr(readtable[i]->creads, readtable[readtable[i]->mindex], J);
+    cout<<" Read "<<i<<" is mapped to "<<readtable[i]->mindex<<" with distance = "<<hd[0]<<" and has
+  weight = "<<readtable[i]->weight<<endl;
   }
   */
-  //q = readmap.size();
-  q = 0;
+    // q = readmap.size();
+    q = 0;
 
-  for(i=0; i<n; i++){
-    if(readtable[i]->weight > 0)
-      q++;
-  }
-
-  stat_file << "# q = " << q << endl;
-
-  readtable2 = (crnode**)calloc(q, sizeof(crnode*));
-
-  for(i=0; i<q; i++){
-    readtable2[i] = (crnode*)malloc(sizeof(crnode));
-    //  readtable2[i]->creads = new int[J/10 + 1];
-    readtable2[i]->weight = 0;
-    readtable2[i]->mindex = 0;
-    readtable2[i]->mindices = new int[LIMIT + 1]; 
-  }
-  
-  int wcount;
-
-  for(i=0; i<q; i++){
-    for(wcount=0; wcount<LIMIT + 1; wcount++)
-      readtable2[i]->mindices[wcount] = 0;
-  }
-
-  j = 0;
-  unsigned int hope;
-  int* itrack = new int[q];
-
-  for(i=0; i<q; i++)
-    itrack[i] = 0;
-
-  for(i=0; i<n; i++){
-    if(readtable[i]->weight > 0){
-      readtable2[j]->creads = readtable[i]->creads;
-      readtable2[j]->missing = readtable[i]->missing;
-      readtable2[j]->mindex = i;
-      readtable2[j]->weight = readtable[i]->weight;
-      readtable2[j]->mindices[0] = i;
-      itrack[j]++;
-      j++;
+    for (i = 0; i < n; i++) {
+        if (readtable[i]->weight > 0) q++;
     }
-    else{
-      for(hope=0; hope<j; hope++){
-        if(readtable2[hope]->mindex == readtable[i]->mindex){
-          readtable2[hope]->mindices[itrack[hope]] = i;
-          itrack[hope]++;
+
+    stat_file << "# q = " << q << endl;
+
+    readtable2 = (crnode**)calloc(q, sizeof(crnode*));
+
+    for (i = 0; i < q; i++) {
+        readtable2[i] = (crnode*)malloc(sizeof(crnode));
+        //  readtable2[i]->creads = new int[J/10 + 1];
+        readtable2[i]->weight = 0;
+        readtable2[i]->mindex = 0;
+        readtable2[i]->mindices = new int[LIMIT + 1];
+    }
+
+    int wcount;
+
+    for (i = 0; i < q; i++) {
+        for (wcount = 0; wcount < LIMIT + 1; wcount++)
+            readtable2[i]->mindices[wcount] = 0;
+    }
+
+    j = 0;
+    unsigned int hope;
+    int* itrack = new int[q];
+
+    for (i = 0; i < q; i++)
+        itrack[i] = 0;
+
+    for (i = 0; i < n; i++) {
+        if (readtable[i]->weight > 0) {
+            readtable2[j]->creads = readtable[i]->creads;
+            readtable2[j]->missing = readtable[i]->missing;
+            readtable2[j]->mindex = i;
+            readtable2[j]->weight = readtable[i]->weight;
+            readtable2[j]->mindices[0] = i;
+            itrack[j]++;
+            j++;
+        } else {
+            for (hope = 0; hope < j; hope++) {
+                if (readtable2[hope]->mindex == readtable[i]->mindex) {
+                    readtable2[hope]->mindices[itrack[hope]] = i;
+                    itrack[hope]++;
+                }
+            }
         }
-      }
     }
-  }
 
+    delete[] itrack;
+    build_assignment(stat_file);
 
-  delete[] itrack;
-  build_assignment(stat_file);
+    stat_file << "# Assignment built" << endl;
 
-  stat_file << "# Assignment built" << endl;
+    stat_file << "# +++++++++++++++++++ BEFORE THE SAMPLING +++++++++++++++++++\n";
+    //  print_stats(out_file, mxt, J);
+    out_file << setw(6) << "#iter";
+    out_file << setw(8) << "class";
+    out_file << setw(8) << "untouch";
+    out_file << setw(9) << "theta";
+    out_file << setw(9) << "gamma\n";
 
-  stat_file << "# +++++++++++++++++++ BEFORE THE SAMPLING +++++++++++++++++++\n";
-  //  print_stats(out_file, mxt, J);
-  out_file << setw(6) << "#iter";
-  out_file << setw(8) << "class";
-  out_file << setw(8) << "untouch";
-  out_file << setw(9) << "theta";
-  out_file << setw(9) << "gamma\n";
-  
-  
-  /*********************
+    /*********************
     sampling procedure
   *********************/
-  (void) time(&t1);
-   
-  int* temp;
-  temp = new int[J/10 + 1];
-   
-  for(k=0; k<=iter; k++){
+    (void)time(&t1);
+
+    int* temp;
+    temp = new int[J / 10 + 1];
+
+    for (k = 0; k <= iter; k++) {
 #ifdef DEBUG
-    printf("-----------------------------------------------\n");
-    printf("-----------> sampling the %ith time <-----------\n", k);
-    printf("-----------------------------------------------\n");
+        printf("-----------------------------------------------\n");
+        printf("-----------> sampling the %ith time <-----------\n", k);
+        printf("-----------------------------------------------\n");
 #endif
-    
-    /// Modify alpha reading from an external file
-    alphafile = fopen(alphastr.c_str(), "r");
-    if (alphafile != NULL){
-      fscanf(alphafile, "%f", &alpha2);
-      alpha = alpha2;
-      fclose(alphafile);
-    }
 
-    /// Modify iter reading from an external file
-    iterfile = fopen(iterstr.c_str(), "r");
-    if (iterfile != NULL){
-      fscanf(iterfile, "%ui", &iter2);
-      if (iter != iter2 and iter2 > k+100){
-        if (iter2 < iter){
-          HISTORY = iter2 - k - 1;
-          cerr << "HISTORY just changed to " << HISTORY << endl;
+        /// Modify alpha reading from an external file
+        alphafile = fopen(alphastr.c_str(), "r");
+        if (alphafile != NULL) {
+            fscanf(alphafile, "%f", &alpha2);
+            alpha = alpha2;
+            fclose(alphafile);
         }
-        iter = iter2;
-      }
-      fclose(iterfile);
-    }
 
-    tot_untouch = 0;
-    // sample classes for all reads
-    for(i=0; i<q; i++){
-      samp_stat = sample_class(i, k);
-      tot_untouch  += samp_stat->untouched;
-      new_proposed += samp_stat->proposed;
-    }
-    
-    // sample haplotypes from reads
-    tn = mxt;
-    K1 = 0;
-    dt = 0.0;
-    dk1 = 0;
-    hapbases = 0;
-    while(tn != NULL){
-      sample_hap(tn);
-      conversion(temp, tn->h, J);
-      tr = tn->rlist;
-      while (tr != NULL){
-        p = seq_distance_new(temp, readtable2[tr->ri], J);
-        //p = seq_distance(tn->h, r[tr->ri], J);
-        dt += p.second * readtable2[tr->ri]->weight;
-        //dt += p[1];
-        //dt += p[0];
-        tr = tr->next;
-      }
-      
-      // compute distance of all reads to their haplotype
-      for (ll=0; ll<q; ll++){
-        p = seq_distance_new(temp, readtable2[ll], J);
-        //p = seq_distance(tn->h, r[ll], J);
-        tn->rd0[ll] = p.first;
-        tn->rd1[ll] = p.second;
-      }
-      
-      // compute distance of haplotypes to reference
-      //p = seq_distance_new(conversion(tn->h, J), conversion(h, J), J);
-      p = seq_distance(tn->h, h, J);
-      dk1 += p.second;
-      hapbases += p.first + p.second; //J - (number of positions reporting N's)
-      K1++;
-      
-      if(k == iter - HISTORY + 1){// starts recording
-        if(record == 0){
-          //create_history(k);
-          record = 1;
+        /// Modify iter reading from an external file
+        iterfile = fopen(iterstr.c_str(), "r");
+        if (iterfile != NULL) {
+            fscanf(iterfile, "%ui", &iter2);
+            if (iter != iter2 and iter2 > k + 100) {
+                if (iter2 < iter) {
+                    HISTORY = iter2 - k - 1;
+                    cerr << "HISTORY just changed to " << HISTORY << endl;
+                }
+                iter = iter2;
+            }
+            fclose(iterfile);
         }
-      }
-      
-      if(record)
-        record_conf(tn, HISTORY + k - iter - 1);
-      
 
-      tn = tn->next;
-    }
-    
-    double b_alpha = 0.0, b_beta = 0.0;
-    
-    b_alpha =  dt + (eps1 * eps2 * totbases);
-    b_beta = (totbases - dt) + eps2 * totbases * (1 - eps1);
+        tot_untouch = 0;
+        // sample classes for all reads
+        for (i = 0; i < q; i++) {
+            samp_stat = sample_class(i, k);
+            tot_untouch += samp_stat->untouched;
+            new_proposed += samp_stat->proposed;
+        }
 
-    theta = gsl_ran_beta(rg, b_alpha, b_beta); 
-    //theta = dt/(q * J) + gsl_ran_gaussian(rg, g_noise);
-    //theta = dt/totbases + gsl_ran_gaussian(rg, g_noise);
-    //theta = (totbases - dt)/totbases + gsl_ran_gaussian(rg, g_noise);
-    gam = (double)dk1/hapbases;
+        // sample haplotypes from reads
+        tn = mxt;
+        K1 = 0;
+        dt = 0.0;
+        dk1 = 0;
+        hapbases = 0;
+        while (tn != NULL) {
+            sample_hap(tn);
+            conversion(temp, tn->h, J);
+            tr = tn->rlist;
+            while (tr != NULL) {
+                p = seq_distance_new(temp, readtable2[tr->ri], J);
+                // p = seq_distance(tn->h, r[tr->ri], J);
+                dt += p.second * readtable2[tr->ri]->weight;
+                // dt += p[1];
+                // dt += p[0];
+                tr = tr->next;
+            }
 
-    // HACK!!! theta=1 gives undesired behaviour; not elegant, but effective
-    if(theta >= 1.0)
-      theta = 0.9999;
-    if(theta <= 0.0)
-      theta = 0.0001;
-    // sample_ref();    // sampling the reference every step gives strange behaviour...
-    
+            // compute distance of all reads to their haplotype
+            for (ll = 0; ll < q; ll++) {
+                p = seq_distance_new(temp, readtable2[ll], J);
+                // p = seq_distance(tn->h, r[ll], J);
+                tn->rd0[ll] = p.first;
+                tn->rd1[ll] = p.second;
+            }
+
+            // compute distance of haplotypes to reference
+            // p = seq_distance_new(conversion(tn->h, J), conversion(h, J), J);
+            p = seq_distance(tn->h, h, J);
+            dk1 += p.second;
+            hapbases += p.first + p.second;  // J - (number of positions reporting N's)
+            K1++;
+
+            if (k == iter - HISTORY + 1) {  // starts recording
+                if (record == 0) {
+                    // create_history(k);
+                    record = 1;
+                }
+            }
+
+            if (record) record_conf(tn, HISTORY + k - iter - 1);
+
+            tn = tn->next;
+        }
+
+        double b_alpha = 0.0, b_beta = 0.0;
+
+        b_alpha = dt + (eps1 * eps2 * totbases);
+        b_beta = (totbases - dt) + eps2 * totbases * (1 - eps1);
+
+        theta = gsl_ran_beta(rg, b_alpha, b_beta);
+        // theta = dt/(q * J) + gsl_ran_gaussian(rg, g_noise);
+        // theta = dt/totbases + gsl_ran_gaussian(rg, g_noise);
+        // theta = (totbases - dt)/totbases + gsl_ran_gaussian(rg, g_noise);
+        gam = (double)dk1 / hapbases;
+
+        // HACK!!! theta=1 gives undesired behaviour; not elegant, but effective
+        if (theta >= 1.0) theta = 0.9999;
+        if (theta <= 0.0) theta = 0.0001;
+// sample_ref();    // sampling the reference every step gives strange behaviour...
+
 #ifdef DEBUG
-    cerr << "dt=" << dt <<  "\ttheta=" << theta<< "\tgamma=" << gam << endl;
+        cerr << "dt=" << dt << "\ttheta=" << theta << "\tgamma=" << gam << endl;
 #endif
-    //    out_file("iteration\t%i\t%i\t%i\t%f\t%f\n", k+1, count_classes(mxt), tot_untouch, theta, gam); 
-    out_file << setw(6) << k+1;// << "\t";
-    out_file << setw(8) << count_classes(mxt);// << "\t";
-    out_file << setw(8) << tot_untouch;// << "\t";
-    out_file << setw(10) << setprecision(6) << theta  << setw(10) << gam << endl;
-  }
-  
-  if( remove( iterstr.c_str() ) != 0 )
-    stat_file << "# iter file was not created" << endl;
-  else
-    stat_file << "# iter file successfully deleted" << endl;
-  
-  if( remove( alphastr.c_str() ) != 0 )
-    stat_file << "# alpha file was not created" << endl;
-  else
-    stat_file << "# alpha file successfully deleted" << endl;
-  
-  (void) time(&t2);
-  
-  /*********************
+        //    out_file("iteration\t%i\t%i\t%i\t%f\t%f\n", k+1, count_classes(mxt), tot_untouch,
+        //    theta, gam);
+        out_file << setw(6) << k + 1;               // << "\t";
+        out_file << setw(8) << count_classes(mxt);  // << "\t";
+        out_file << setw(8) << tot_untouch;         // << "\t";
+        out_file << setw(10) << setprecision(6) << theta << setw(10) << gam << endl;
+    }
+
+    if (remove(iterstr.c_str()) != 0)
+        stat_file << "# iter file was not created" << endl;
+    else
+        stat_file << "# iter file successfully deleted" << endl;
+
+    if (remove(alphastr.c_str()) != 0)
+        stat_file << "# alpha file was not created" << endl;
+    else
+        stat_file << "# alpha file successfully deleted" << endl;
+
+    (void)time(&t2);
+
+    /*********************
       sampling ends
   *********************/
-  
-  stat_file << "# Survived sampling" << endl;
-  stat_file << "# sampling took " << difftime(t2, t1) << " seconds\n";
-  
-  //  write_assignment(k, new_proposed, mxt);
-  
-  stat_file << "\n\n# +++++++++++++++++++ AFTER THE SAMPLING ++++++++++++++++++++\n";
-  print_stats(stat_file, mxt, J);
-  stat_file << "\n# reference genome is:\n# ";
-  for(j=0; j<J; j++)
-    stat_file << i2dna_code[h[j]];
-  stat_file << "\n\n\n";
-  stat_file << "\n#gamma = " << gam << endl;
-  stat_file << "\n#theta = " << theta << endl;
-  stat_file << "\n#final number of components = " << K1 << "\n";
-  stat_file << "\n#made "<< new_proposed << " new clusters\n";
-  stat_file << "\n#number of haplotypes in history = " << haplotypecount << endl;
-  
-  /******************
+
+    stat_file << "# Survived sampling" << endl;
+    stat_file << "# sampling took " << difftime(t2, t1) << " seconds\n";
+
+    //  write_assignment(k, new_proposed, mxt);
+
+    stat_file << "\n\n# +++++++++++++++++++ AFTER THE SAMPLING ++++++++++++++++++++\n";
+    print_stats(stat_file, mxt, J);
+    stat_file << "\n# reference genome is:\n# ";
+    for (j = 0; j < J; j++)
+        stat_file << i2dna_code[h[j]];
+    stat_file << "\n\n\n";
+    stat_file << "\n#gamma = " << gam << endl;
+    stat_file << "\n#theta = " << theta << endl;
+    stat_file << "\n#final number of components = " << K1 << "\n";
+    stat_file << "\n#made " << new_proposed << " new clusters\n";
+    stat_file << "\n#number of haplotypes in history = " << haplotypecount << endl;
+
+    /******************
     write corrected
   ******************/
-  
-  /*
+
+    /*
   fprintf(stderr, "# writing corrected\n");
   FILE* corr;
   if( (corr = fopen("corrected.tmp", "w")) == NULL ){
     printf("Impossible to write file corrected.tmp\n");
     exit(EXIT_FAILURE);
   }
-  
+
   for(i=0;i<n;i++) {
     quality = setfinalhaplotype(i);
     j=0;
@@ -466,36 +460,36 @@ int main(int argc, char** argv){
     for(j=0; j<J; j++)fprintf(corr,"%c",i2dna_code[r[i][j]]);
     fprintf(corr,"\n");
   }
-  
+
   if(ho_flag) {
     write_haplotype_frequencies(haplotype_output, ho_count);
   }
-  */  
-  
-  write_posterior_files(instr);
-  
-  cleanup();
-  (void) time(&t1);
-  stat_file << "# after sampling took " << difftime(t1, t2) << " seconds" << endl;
-  /*
+  */
+
+    write_posterior_files(instr);
+
+    cleanup();
+    (void)time(&t1);
+    stat_file << "# after sampling took " << difftime(t1, t2) << " seconds" << endl;
+    /*
   tn = mxt;
   cnode* tn2;
   int difference = 0, similarity = 0, alt_diff = 0, alt_sim = 0, it;
-  
+
   while(tn != NULL){
     tr = tn->rlist;
     cout<<tn->ci<<endl;
     while(tr != NULL){
       for(it=0; it < readtable2[tr->ri]->weight; it++)
-	cout<<readtable2[tr->ri]->mindices[it]<<"   ";
+    cout<<readtable2[tr->ri]->mindices[it]<<"   ";
       cout<<"   "<<tr->ri<<"  weight = "<<readtable2[tr->ri]->weight<<"   "<<tn->rd0[tr->ri]<<"  ";
       // if(tn->rd0[tr->ri] >= 0){
       tn2 = mxt;
       while(tn2 != NULL){
-	cout<<"distance to "<<tn2->ci<<" = "<<tn2->rd0[tr->ri]<<"   ";
-	tn2 = tn2->next;
+    cout<<"distance to "<<tn2->ci<<" = "<<tn2->rd0[tr->ri]<<"   ";
+    tn2 = tn2->next;
       }
-	// }
+    // }
       cout<<endl;
       difference += tn->rd0[tr->ri];
       similarity += tn->rd1[tr->ri];
@@ -511,189 +505,186 @@ int main(int argc, char** argv){
   cout<<"alt_diff = "<<alt_diff<<"\talt_sim = "<<alt_sim<<endl;
   cout<<"\ttotbases = "<<totbases<<"\tq * J = "<<q * J<<endl;
   */
-  delete[] temp;
-  return 0;
+    delete[] temp;
+    return 0;
 }
 
-
-void read_data(char* filename, ofstream& out_file)
+void read_data(char* filename, std::ofstream& out_file)
 {
-  FILE* data;
-  char c;
-  unsigned int seq=0, i, j=0, k=0;
-  out_file << "# reading data\n";
-  if( (data = fopen(filename, "r")) == NULL){
-    out_file << "Impossible to open file " << filename << "\n";
-    exit(EXIT_FAILURE);
-  }
+    FILE* data;
+    char c;
+    unsigned int seq = 0, i, j = 0, k = 0;
+    out_file << "# reading data\n";
+    if ((data = fopen(filename, "r")) == NULL) {
+        out_file << "Impossible to open file " << filename << "\n";
+        exit(EXIT_FAILURE);
+    }
 
-  for (;;) // first sweep to count
+    for (;;)  // first sweep to count
     {
-      c = fgetc(data);
-      
-      if (c == '>'){
-	n++;
-	seq = 0;
-      }
-      if (c == '\n')
-	seq = 1;
+        c = fgetc(data);
 
-      if (isdna(c) && seq) {
-	totsites++;
-	if (d2i(c) != B)
-	  totbases++;
-      }
-      
-      if (c == EOF)
-	break;
+        if (c == '>') {
+            n++;
+            seq = 0;
+        }
+        if (c == '\n') seq = 1;
+
+        if (isdna(c) && seq) {
+            totsites++;
+            if (d2i(c) != B) totbases++;
+        }
+
+        if (c == EOF) break;
     }
-  
-  if (n == 0) {
-    cout << "Error: No data found!\n";
-    exit(EXIT_FAILURE);
-  }
 
-  J = totsites/n; // assuming fixed length reads
-  
-  fclose(data);
-
-  if(n == 1) {
-    out_file << "Nothing to do, have only one read... (n == 1)\n";
-    exit(0);
-  }
-  
-  out_file << "# totbases = "<< totbases << "\ttotsites = " << totsites << "\n";
-  
-  ///allocate memory for r[i][j], id[i], read2hap[i]
-  r = (short unsigned int**)calloc(n, sizeof(unsigned short int*));
-  if (r == NULL) exit(EXIT_FAILURE);
-  id = (char**)calloc(n, sizeof(char*));
-  if (id == NULL) exit(EXIT_FAILURE);
-  
-  /// This defines an array of maps
-  /// to store the haplotypes every read has been assigned to
-  pair <sup_map*, ptrdiff_t> read2hap_pair = get_temporary_buffer<sup_map>(n);
-  new (read2hap_pair.first) sup_map[n];
-  read2hap = read2hap_pair.first;
-  
-  for (i = 0; i < n; i++){
-    r[i]  = (unsigned short int*)calloc(J, sizeof(unsigned short int));
-    id[i] = (char*)calloc(100, sizeof(char));
-  }
-  
-  if( (data = fopen(filename, "r")) == NULL){
-    printf("Impossible to REopen file %s\n", filename);
-    exit(EXIT_FAILURE);
-  }
-  
-  i = -1;
-  for (;;)  {// second sweep to read
-      c = fgetc(data);
-      
-      if (c == '>'){
-	i++;
-	seq = 0;
-	k = 0;
-      }
-      if (seq == 0 and c != '\n'){
-	id[i][k] = c;
-	k++;
-      }
-      if (seq == 0 && c == '\n'){
-	seq = 1;
-	j=0;
-      }
-      
-      if (isdna(c) && seq){
-	r[i][j] = d2i(c);
-	j++;
-      }
-      if (c == EOF)
-	break;
-  }
-  
-  fclose(data);
-
-}
-
-void read_conversion(crnode* b, unsigned short int* a, int seq_length){
-  int i, j, temp;
-//   crnode* b = (crnode*)malloc(sizeof(crnode));
-
-//   b->creads = new int[seq_length/10 + 1];
-//   b->missing = 0;
-//   b->mindices = new int[LIMIT + 1];
- 
-  for(i=0; i<seq_length/10 + 1; i++)
-    b->creads[i] = 0;
-
-  for(i=0; i<seq_length/10; i++){
-    for(j=10; j>0; j--){
-      // NOTE: slightly faster version using bitwise left shift operator 
-      b->creads[i] += a[10*(i+1)-j] << 3*(j-1);
-      b->missing += (a[10 * i + 10 - j] == B);
+    if (n == 0) {
+        cout << "Error: No data found!\n";
+        exit(EXIT_FAILURE);
     }
-  }
 
-  for(j=10; j>(10 - (seq_length%10)); j--){
-    temp = (int) pow(8.0, (double)j-1);
-    b->creads[i] += temp * a[10 * i + 10 -j];
-    b->missing += (a[10 * i + 10 - j] == B);
-  }
-  
-  return;
-}
+    J = totsites / n;  // assuming fixed length reads
 
+    fclose(data);
 
-void conversion(int* b, unsigned short int* a, int seq_length){
-  int i, j, temp;
-  //b = new int[seq_length/10 + 1];
-
-  for(i=0; i<seq_length/10 + 1; i++) b[i] = 0;
-
-  for(i=0; i<seq_length/10; i++){
-    for(j=10; j>0; j--){
-      temp = (int) pow(8.0, (double)j-1);
-      b[i] += temp * a[10 * i + 10 - j];
+    if (n == 1) {
+        out_file << "Nothing to do, have only one read... (n == 1)\n";
+        exit(0);
     }
-  }
 
-  for(j=10; j>(10 - (seq_length%10)); j--){
-    temp = (int) pow(8.0, (double)j-1);
-    b[i] += temp * a[10 * i + 10 -j];
-  }
+    out_file << "# totbases = " << totbases << "\ttotsites = " << totsites << "\n";
 
-  return;// b;
+    /// allocate memory for r[i][j], id[i], read2hap[i]
+    r = (short unsigned int**)calloc(n, sizeof(unsigned short int*));
+    if (r == NULL) exit(EXIT_FAILURE);
+    id = (char**)calloc(n, sizeof(char*));
+    if (id == NULL) exit(EXIT_FAILURE);
+
+    /// This defines an array of maps
+    /// to store the haplotypes every read has been assigned to
+    std::pair<sup_map*, std::ptrdiff_t> read2hap_pair = std::get_temporary_buffer<sup_map>(n);
+    new (read2hap_pair.first) sup_map[n];
+    read2hap = read2hap_pair.first;
+
+    for (i = 0; i < n; i++) {
+        r[i] = (unsigned short int*)calloc(J, sizeof(unsigned short int));
+        id[i] = (char*)calloc(100, sizeof(char));
+    }
+
+    if ((data = fopen(filename, "r")) == NULL) {
+        printf("Impossible to REopen file %s\n", filename);
+        exit(EXIT_FAILURE);
+    }
+
+    i = -1;
+    for (;;) {  // second sweep to read
+        c = fgetc(data);
+
+        if (c == '>') {
+            i++;
+            seq = 0;
+            k = 0;
+        }
+        if (seq == 0 and c != '\n') {
+            id[i][k] = c;
+            k++;
+        }
+        if (seq == 0 && c == '\n') {
+            seq = 1;
+            j = 0;
+        }
+
+        if (isdna(c) && seq) {
+            r[i][j] = d2i(c);
+            j++;
+        }
+        if (c == EOF) break;
+    }
+
+    fclose(data);
 }
 
-int weight(const cnode* wn){
-  int w = 0;
-  rnode* rn = wn->rlist;
-      
-  while(rn != NULL){
-    w += readtable2[rn->ri]->weight;
-    rn = rn->next;
-  }
+void read_conversion(crnode* b, unsigned short int* a, int seq_length)
+{
+    int i, j, temp;
+    //   crnode* b = (crnode*)malloc(sizeof(crnode));
 
-  return w;
+    //   b->creads = new int[seq_length/10 + 1];
+    //   b->missing = 0;
+    //   b->mindices = new int[LIMIT + 1];
+
+    for (i = 0; i < seq_length / 10 + 1; i++)
+        b->creads[i] = 0;
+
+    for (i = 0; i < seq_length / 10; i++) {
+        for (j = 10; j > 0; j--) {
+            // NOTE: slightly faster version using bitwise left shift operator
+            b->creads[i] += a[10 * (i + 1) - j] << 3 * (j - 1);
+            b->missing += (a[10 * i + 10 - j] == B);
+        }
+    }
+
+    for (j = 10; j > (10 - (seq_length % 10)); j--) {
+        temp = (int)pow(8.0, (double)j - 1);
+        b->creads[i] += temp * a[10 * i + 10 - j];
+        b->missing += (a[10 * i + 10 - j] == B);
+    }
+
+    return;
 }
 
-int weight_shift(const cnode* wn, unsigned int i, unsigned int removed){
-  int w = wn->weight;
-  // retrieve the component to which read i has been assigned to
-  cnode* cn = (c_ptr[i] != NULL) ? c_ptr[i]->next : mxt;
-  if(!removed && cn == wn)
-    w -= readtable2[i]->weight;
+void conversion(int* b, unsigned short int* a, int seq_length)
+{
+    int i, j, temp;
+    // b = new int[seq_length/10 + 1];
 
-  return w;
+    for (i = 0; i < seq_length / 10 + 1; i++)
+        b[i] = 0;
+
+    for (i = 0; i < seq_length / 10; i++) {
+        for (j = 10; j > 0; j--) {
+            temp = (int)pow(8.0, (double)j - 1);
+            b[i] += temp * a[10 * i + 10 - j];
+        }
+    }
+
+    for (j = 10; j > (10 - (seq_length % 10)); j--) {
+        temp = (int)pow(8.0, (double)j - 1);
+        b[i] += temp * a[10 * i + 10 - j];
+    }
+
+    return;  // b;
 }
 
-//int weight_final(const cnode* wn){
+int weight(const cnode* wn)
+{
+    int w = 0;
+    rnode* rn = wn->rlist;
+
+    while (rn != NULL) {
+        w += readtable2[rn->ri]->weight;
+        rn = rn->next;
+    }
+
+    return w;
+}
+
+int weight_shift(const cnode* wn, unsigned int i, unsigned int removed)
+{
+    int w = wn->weight;
+    // retrieve the component to which read i has been assigned to
+    cnode* cn = (c_ptr[i] != NULL) ? c_ptr[i]->next : mxt;
+    if (!removed && cn == wn) w -= readtable2[i]->weight;
+
+    return w;
+}
+
+// int weight_final(const cnode* wn){
 //  int w = 0;
 //  rnode* rn = NULL;
-//  
+//
 //  rn = wn->rlist;
-//      
+//
 //  while(rn != NULL){
 //    w += readtable2[rn->ri]->weight;
 //    rn = rn->next;
@@ -702,418 +693,415 @@ int weight_shift(const cnode* wn, unsigned int i, unsigned int removed){
 //  return w;
 //}
 
-void build_assignment(ofstream& out_file){
-  
-  unsigned int i, m, ll;
-  unsigned int ci;
-  cnode* cn;
-  rnode* rn;
-  pair<int,int> p;
-  double* p_k;
-  //double* p_q;
-  gsl_ran_discrete_t* g;
-  
-  out_file << "# Building assignment" << endl;
-  h = (short unsigned int*)calloc(J, sizeof(unsigned int));
-  c_ptr = (cnode**)calloc(n, sizeof(cnode*));
+void build_assignment(std::ofstream& out_file)
+{
 
-  MAX_K = n + 1;
-  P = (double*) calloc((MAX_K), sizeof(double));
-  log_P = (double*) calloc((MAX_K), sizeof(double));
-  cl_ptr = (cnode**) calloc((MAX_K), sizeof(cnode*));
-  
-  // if avgNK is set (>0), calculate K
-  if(avgNK > 0.0) {
-    K = (int)(1.*n/avgNK);
-  }
-  // otherwise K is already set as commandline option
-  // K == 0 can happen with very few reads...
+    unsigned int i, m, ll;
+    unsigned int ci;
+    cnode* cn;
+    rnode* rn;
+    std::pair<int, int> p;
+    double* p_k;
+    // double* p_q;
+    gsl_ran_discrete_t* g;
 
-  // no empty clusters at the beginning 
-  if ((n < K) || (K == 0))
-    K = n;
-  
-  lowest_free = K;
-  p_k = (double*)malloc(K*sizeof(double));
-  //p_q = (double*)malloc(K*sizeof(double));  
+    out_file << "# Building assignment" << std::endl;
+    h = (short unsigned int*)calloc(J, sizeof(unsigned int));
+    c_ptr = (cnode**)calloc(n, sizeof(cnode*));
 
-  // make the class list of K (or q?) initial components 
+    MAX_K = n + 1;
+    P = (double*)calloc((MAX_K), sizeof(double));
+    log_P = (double*)calloc((MAX_K), sizeof(double));
+    cl_ptr = (cnode**)calloc((MAX_K), sizeof(cnode*));
 
-  out_file << "# Initial number of clusters, K = " << K << endl;
-
-  // create a linked list storing clusters/components/classes. 
-  // nodes are of type cnode's. 
-  mxt = NULL;
-  for(i=0; i<K; i++) {
-    add_comp(&mxt, &hst, i, 0, NULL, NULL, NULL, NULL, J, 0, record);
-    p_k[i] = 1.;
-    //p_q[i] = 1;
-  }
-  g = gsl_ran_discrete_preproc(K, p_k);
-  
-  // assign reads to initial clusters randomly
-  for(m=0; m<q; m++){
-    ci = gsl_ran_discrete(rg, g);
-    cn = mxt;
-    while(cn != NULL) {
-      if(ci == cn->ci){
-        add_read(&cn->rlist, m);
-        cn->size++;
-        break;
-      }
-      cn=cn->next;
+    // if avgNK is set (>0), calculate K
+    if (avgNK > 0.0) {
+        K = (int)(1. * n / avgNK);
     }
-  }
-  gsl_ran_discrete_free(g);
-  free(p_k);
-  //free(p_q);
+    // otherwise K is already set as commandline option
+    // K == 0 can happen with very few reads...
 
-  // there is at least the first cluster...
-  cn = mxt;
-  
-#ifdef DEBUG
-  printf("cluster %d has size %d\n",cn->ci,cn->size);
-#endif
-  
-  cn->h = (unsigned short int *) malloc(J * sizeof(unsigned short int));
-  cn->rd0 = (unsigned short int*) malloc(q * sizeof(unsigned short int));
-  cn->rd1 = (unsigned short int*) malloc(q * sizeof(unsigned short int));
-  
-  while(cn->size == 0) {
-    // or maybe not ...
-    remove_comp(&mxt);
+    // no empty clusters at the beginning
+    if ((n < K) || (K == 0)) K = n;
+
+    lowest_free = K;
+    p_k = (double*)malloc(K * sizeof(double));
+    // p_q = (double*)malloc(K*sizeof(double));
+
+    // make the class list of K (or q?) initial components
+
+    out_file << "# Initial number of clusters, K = " << K << endl;
+
+    // create a linked list storing clusters/components/classes.
+    // nodes are of type cnode's.
+    mxt = NULL;
+    for (i = 0; i < K; i++) {
+        add_comp(&mxt, &hst, i, 0, NULL, NULL, NULL, NULL, J, 0, record);
+        p_k[i] = 1.;
+        // p_q[i] = 1;
+    }
+    g = gsl_ran_discrete_preproc(K, p_k);
+
+    // assign reads to initial clusters randomly
+    for (m = 0; m < q; m++) {
+        ci = gsl_ran_discrete(rg, g);
+        cn = mxt;
+        while (cn != NULL) {
+            if (ci == cn->ci) {
+                add_read(&cn->rlist, m);
+                cn->size++;
+                break;
+            }
+            cn = cn->next;
+        }
+    }
+    gsl_ran_discrete_free(g);
+    free(p_k);
+    // free(p_q);
+
+    // there is at least the first cluster...
     cn = mxt;
-    cn->h = (unsigned short int *) malloc(J * sizeof(unsigned short int));
-    cn->rd0 = (unsigned short int*) malloc(q * sizeof(unsigned short int));
-    cn->rd1 = (unsigned short int*) malloc(q * sizeof(unsigned short int));
-  }
-  sample_hap(cn);
-  int* temp;
-  temp = new int[J/10+1];
-  conversion(temp, cn->h, J);
-  for(ll=0; ll < q; ll++){
-    p = seq_distance_new(temp, readtable2[ll], J);
-    cn->rd0[ll] = p.first;
-    cn->rd1[ll] = p.second;
-  }
-  
-  // have to go through the list with ->next, because dont want to loose connection between the elements of the list
-  // needed for remove_comp, which returns the ->next element of the deleted cluster at the position of the given argument
-  while(cn->next != NULL){
-    // have to allocate mem anyway, otherwise would get error, when freeing memory, which happens when removing cluster
-    cn->next->h = (unsigned short int *) malloc(J * sizeof(unsigned short int));
-    cn->next->rd0 = (unsigned short int*) malloc(q * sizeof(unsigned short int));
-    cn->next->rd1 = (unsigned short int*) malloc(q * sizeof(unsigned short int));
-    
+
 #ifdef DEBUG
-    printf("cluster %d has size %d\n", cn->next->ci, cn->next->size);
+    printf("cluster %d has size %d\n", cn->ci, cn->size);
 #endif
 
-    if(cn->next->size == 0) {
-#ifdef DEBUG
-      printf("removing some node... p=%p\n",cn->next);
-#endif
-      remove_comp(&cn->next);
-    }else{
-      sample_hap(cn->next);
-      conversion(temp, cn->next->h, J);
-      for (ll=0; ll < q; ll++){
+    cn->h = (unsigned short int*)malloc(J * sizeof(unsigned short int));
+    cn->rd0 = (unsigned short int*)malloc(q * sizeof(unsigned short int));
+    cn->rd1 = (unsigned short int*)malloc(q * sizeof(unsigned short int));
+
+    while (cn->size == 0) {
+        // or maybe not ...
+        remove_comp(&mxt);
+        cn = mxt;
+        cn->h = (unsigned short int*)malloc(J * sizeof(unsigned short int));
+        cn->rd0 = (unsigned short int*)malloc(q * sizeof(unsigned short int));
+        cn->rd1 = (unsigned short int*)malloc(q * sizeof(unsigned short int));
+    }
+    sample_hap(cn);
+    int* temp;
+    temp = new int[J / 10 + 1];
+    conversion(temp, cn->h, J);
+    for (ll = 0; ll < q; ll++) {
         p = seq_distance_new(temp, readtable2[ll], J);
-        cn->next->rd0[ll] = p.first;
-        cn->next->rd1[ll] = p.second;
-      }
-      cn = cn->next;
+        cn->rd0[ll] = p.first;
+        cn->rd1[ll] = p.second;
     }
-  }
-  delete[] temp;
 
-  // precompute weights in order to speed-up weight_shift()
-  cn = mxt;
-  while(cn != NULL){
-    cn->weight = weight(cn);
-    cn = cn->next;
-  }
+    // have to go through the list with ->next, because dont want to loose connection between the
+    // elements of the list
+    // needed for remove_comp, which returns the ->next element of the deleted cluster at the
+    // position of the given argument
+    while (cn->next != NULL) {
+        // have to allocate mem anyway, otherwise would get error, when freeing memory, which
+        // happens when removing cluster
+        cn->next->h = (unsigned short int*)malloc(J * sizeof(unsigned short int));
+        cn->next->rd0 = (unsigned short int*)malloc(q * sizeof(unsigned short int));
+        cn->next->rd1 = (unsigned short int*)malloc(q * sizeof(unsigned short int));
 
-  // define the predecessor of each read
-  cn = mxt;
-  
-  rn = cn->rlist;
-  while (rn != NULL){
-    i = rn->ri;
-    c_ptr[i] = NULL;
-    rn = rn->next;
-  }
-  
-  while (cn->next != NULL){
-    
-    rn = cn->next->rlist;
-    while (rn != NULL){
-      i = rn->ri;
-      c_ptr[i] = cn;
-      rn = rn->next;
+#ifdef DEBUG
+        printf("cluster %d has size %d\n", cn->next->ci, cn->next->size);
+#endif
+
+        if (cn->next->size == 0) {
+#ifdef DEBUG
+            printf("removing some node... p=%p\n", cn->next);
+#endif
+            remove_comp(&cn->next);
+        } else {
+            sample_hap(cn->next);
+            conversion(temp, cn->next->h, J);
+            for (ll = 0; ll < q; ll++) {
+                p = seq_distance_new(temp, readtable2[ll], J);
+                cn->next->rd0[ll] = p.first;
+                cn->next->rd1[ll] = p.second;
+            }
+            cn = cn->next;
+        }
     }
-    
-    cn = cn->next;
-  }
-  
-  /*  
+    delete[] temp;
+
+    // precompute weights in order to speed-up weight_shift()
+    cn = mxt;
+    while (cn != NULL) {
+        cn->weight = weight(cn);
+        cn = cn->next;
+    }
+
+    // define the predecessor of each read
+    cn = mxt;
+
+    rn = cn->rlist;
+    while (rn != NULL) {
+        i = rn->ri;
+        c_ptr[i] = NULL;
+        rn = rn->next;
+    }
+
+    while (cn->next != NULL) {
+
+        rn = cn->next->rlist;
+        while (rn != NULL) {
+            i = rn->ri;
+            c_ptr[i] = cn;
+            rn = rn->next;
+        }
+
+        cn = cn->next;
+    }
+
+    /*
   for(i=0; i<n; i++)
     printf("predecessor of %i is %p\n", i, c_ptr[i]);
   */
-  unsigned int rr;
-  
-  int bmax = 0;
-  unsigned short int bi;
+    unsigned int rr;
 
-  /* sample reference genome */
-  for(i=0; i<J; i++){
-    for(rr=0;rr<B;rr++)
-      cbase[rr] = 0;
-    
-    for(rr=0; rr<q; rr++){
-      if(r[readtable2[rr]->mindex][i] < B) {
-     	//cbase[r[rr][i]]++;
-        cbase[r[readtable2[rr]->mindex][i]] += readtable2[rr]->weight;
-        //bmax += 1;
-        bmax += readtable2[rr]->weight;
-      }
-    }
-    if(bmax > 0) { 
-      bmax = cbase[0];
-      bi = 0;
-      for(rr=1; rr<B; rr++) {
-        if(cbase[rr] > bmax) {
-          bmax = cbase[rr];
-          bi = rr;
-        }
-      }
-      h[i] = bi;
-    }
-    else{
-      h[i] = B;
-    }
-  }
-  
-  return;
-}
+    int bmax = 0;
+    unsigned short int bi;
 
+    /* sample reference genome */
+    for (i = 0; i < J; i++) {
+        for (rr = 0; rr < B; rr++)
+            cbase[rr] = 0;
 
-double sample_ref() {
-  cnode* cn;
-  unsigned int i,j;
-  double b1,b2;
-  unsigned int K1 = 0;
-  gsl_ran_discrete_t* g;
-  ofstream err_file("error_ref.log");
-  double max_log_pbase;
-  int max_cbase;
-  unsigned int base_id, dk1=0;
-  unsigned int countbases = 0;
-
-  for(j=0;j<J;j++) {
-
-    K1 = 0;
-    for(i=0;i<B;i++) {
-      cbase[i] = 0;
-      pbase[i] = 0.0;
-    }
-
-    cn = mxt;
-    
-    while(cn != NULL) {
-      if(cn->size > 0) {
-	if(cn->h[j] < B) {
-	  cbase[cn->h[j]]++;
-	  K1++;
-	}
-      }
-      cn=cn->next;
-    }
-
-    countbases += K1;
-
-    if(gam < .2)gam = 0.2;
-
-    b1 = gam;
-    b2 = (1.0-gam)/((double)B - 1.0);
-
-    if(b1 == 0.0) {
-      err_file << "# There is something wrong with GAMMA ( == 0.0), sample ref\n";
-      print_stats(err_file, mxt, J);
-      err_file << "# reference:\n# ";
-      for(i=0;i<J;i++) {
-	err_file << i2dna_code[h[i]];
-      }
-      err_file << "\n";
-      exit(EXIT_FAILURE);
-    }
-
-    if(K1 > 0) {
-      if(b1 != 1.0) {
-	
-	for(i=0; i<B; i++){
-	  log_pbase[i] = cbase[i] * gsl_sf_log(b1) + (K1 - cbase[i]) * gsl_sf_log(b2);
-	}
-	max_log_pbase = log_pbase[0];
-	base_id = 0;
-	
-	for(i=1; i<B; i++) {
-	  if(log_pbase[i] > max_log_pbase) {
-	    max_log_pbase = log_pbase[i];
-	    base_id = i;
-	  }
-	}
-	
-	for(i=0; i<B; i++) {
-	  log_pbase[i] -= max_log_pbase;
-	  if(i == base_id) {
-	    pbase[i] = 1.0;
-	  }
-	  else{
-	    if(log_pbase[i] < double_threshold_min) {
-	      pbase[i] = 0.0;
-	    }
-	    else{
-	      pbase[i] = gsl_sf_exp(log_pbase[i]);
-	    }
-	  }
-	}
-	
-	g = gsl_ran_discrete_preproc(B, pbase);
-	h[j] = gsl_ran_discrete(rg, g);
-	gsl_ran_discrete_free(g);
-      }
-      else{ // gamma == 1.0
-	max_cbase = cbase[0];
-	for(i=1; i<B; i++) {
-	  if(cbase[i] >= max_cbase) {
-	    max_cbase = cbase[i];
-	  }
-	}
-	for(i=0; i< B; i++) {
-	  if(cbase[i] == max_cbase) {
-	    pbase[i] = 1.0;
-	  }
-	  else {
-	    pbase[i] = 0.0;
-	  }
-	}
-	g = gsl_ran_discrete_preproc(B, pbase);
-	h[j] = gsl_ran_discrete(rg, g);
-	gsl_ran_discrete_free(g);
-      }
-    }
-    else{ // K1 == 0, that is all N's
-      h[j] = B;
-    }
-    dk1 += cbase[h[j]];
-  }
-  return (double)dk1/(double)countbases;
-}
-
-void sample_hap(cnode* cn){
-  
-  rnode* tr;
-  unsigned int i, j, tot_reads;
-  gsl_ran_discrete_t* g;
-  double b1, b2;
-
-  double max_log_pbase;
-  int max_cbase;
-  unsigned int base_id;
-
-#ifdef DEBUG
-  printf("Haplotype %i is\n", cn->ci);
-#endif
-
-  for (j=0; j<J; j++){
-    
-    tot_reads = 0;
-    for(i=0; i<B; i++) {
-      cbase[i] = 0;
-      pbase[i] = 0.0;
-    }
-
-    tr = cn->rlist;
-    while (tr != NULL){ // correct for missing data
-      if (r[readtable2[tr->ri]->mindex][j] < B) {
-        cbase[r[readtable2[tr->ri]->mindex][j]] += readtable2[tr->ri]->weight;
-        //cbase[r[readtable2[tr->ri]->mindex][j]] ++;
-        //cbase[r[tr->ri][j]]++;
-        tot_reads += readtable2[tr->ri]->weight;
-        //tot_reads++;
-      }
-      tr = tr->next;
-    }
-
-    b1 = theta;
-    b2 = (1. - theta)/((double)B-1);
-    
-    if(b1 == 0.0) {
-      printf("# There is something wrong with THETA ( == 0.0)\n");
-      exit(EXIT_FAILURE);
-    }
-
-    if(b1 != 1.0) {	
-      for(i=0; i<B; i++){
-        if(tot_reads > 0) { //base is not N: sample from reads in the cluster
-          log_pbase[i] = cbase[i] * gsl_sf_log(b1) + (tot_reads - cbase[i]) * gsl_sf_log(b2);
-        }
-        else //base is N: sample from all reads
-          log_pbase[i] = ftable[j][i] * gsl_sf_log(b1) + (ftable_sum[j] - ftable[j][i]) * gsl_sf_log(b2);	      
-      }
-      max_log_pbase = log_pbase[0];
-      base_id = 0;
-      for(i=1; i<B; i++) {
-        if(log_pbase[i] > max_log_pbase) {
-          max_log_pbase = log_pbase[i];
-          base_id = i;
-        }
-      }
-      for(i=0; i<B; i++) {
-        if(i == base_id) {
-          pbase[i] = 1.0;
-        }else{
-          log_pbase[i] -= max_log_pbase;
-          if(log_pbase[i] < double_threshold_min) {
-            pbase[i] = 0.0;
-          }else{
-            //cout<<"log_pbase["<<i<<"] = "<<log_pbase[i]<<endl;
-            pbase[i] = gsl_sf_exp(log_pbase[i]);
-          }
-        }
-      }
-	
-      g = gsl_ran_discrete_preproc(B, pbase);
-      cn->h[j] = gsl_ran_discrete(rg, g);
-      gsl_ran_discrete_free(g);
-    }
-    else{ // theta == 1.0
-      if(tot_reads>0){//base not N: sample from reads in cluster.
-        max_cbase = cbase[0];
-        base_id = 0;
-        for(i=1; i<B; i++) {
-          if(cbase[i] >= max_cbase) {
-            max_cbase = cbase[i];
-            base_id = i;
+        for (rr = 0; rr < q; rr++) {
+            if (r[readtable2[rr]->mindex][i] < B) {
+                // cbase[r[rr][i]]++;
+                cbase[r[readtable2[rr]->mindex][i]] += readtable2[rr]->weight;
+                // bmax += 1;
+                bmax += readtable2[rr]->weight;
             }
         }
-        cn->h[j] = base_id;
-      }
-      else{//missing data: sample from all reads.
-        max_cbase = ftable[j][0];
-        base_id = 0;
-        for(i=1; i<B; i++) {
-          if(ftable[j][i] >= max_cbase) {
-            max_cbase = ftable[j][i];
-            base_id = i;
-          }
+        if (bmax > 0) {
+            bmax = cbase[0];
+            bi = 0;
+            for (rr = 1; rr < B; rr++) {
+                if (cbase[rr] > bmax) {
+                    bmax = cbase[rr];
+                    bi = rr;
+                }
+            }
+            h[i] = bi;
+        } else {
+            h[i] = B;
         }
-        cn->h[j] = base_id;
-      }
     }
-    
-    /*
+
+    return;
+}
+
+double sample_ref()
+{
+    cnode* cn;
+    unsigned int i, j;
+    double b1, b2;
+    unsigned int K1 = 0;
+    gsl_ran_discrete_t* g;
+    std::ofstream err_file("error_ref.log");
+    double max_log_pbase;
+    int max_cbase;
+    unsigned int base_id, dk1 = 0;
+    unsigned int countbases = 0;
+
+    for (j = 0; j < J; j++) {
+
+        K1 = 0;
+        for (i = 0; i < B; i++) {
+            cbase[i] = 0;
+            pbase[i] = 0.0;
+        }
+
+        cn = mxt;
+
+        while (cn != NULL) {
+            if (cn->size > 0) {
+                if (cn->h[j] < B) {
+                    cbase[cn->h[j]]++;
+                    K1++;
+                }
+            }
+            cn = cn->next;
+        }
+
+        countbases += K1;
+
+        if (gam < .2) gam = 0.2;
+
+        b1 = gam;
+        b2 = (1.0 - gam) / ((double)B - 1.0);
+
+        if (b1 == 0.0) {
+            err_file << "# There is something wrong with GAMMA ( == 0.0), sample ref\n";
+            print_stats(err_file, mxt, J);
+            err_file << "# reference:\n# ";
+            for (i = 0; i < J; i++) {
+                err_file << i2dna_code[h[i]];
+            }
+            err_file << "\n";
+            exit(EXIT_FAILURE);
+        }
+
+        if (K1 > 0) {
+            if (b1 != 1.0) {
+
+                for (i = 0; i < B; i++) {
+                    log_pbase[i] = cbase[i] * gsl_sf_log(b1) + (K1 - cbase[i]) * gsl_sf_log(b2);
+                }
+                max_log_pbase = log_pbase[0];
+                base_id = 0;
+
+                for (i = 1; i < B; i++) {
+                    if (log_pbase[i] > max_log_pbase) {
+                        max_log_pbase = log_pbase[i];
+                        base_id = i;
+                    }
+                }
+
+                for (i = 0; i < B; i++) {
+                    log_pbase[i] -= max_log_pbase;
+                    if (i == base_id) {
+                        pbase[i] = 1.0;
+                    } else {
+                        if (log_pbase[i] < double_threshold_min) {
+                            pbase[i] = 0.0;
+                        } else {
+                            pbase[i] = gsl_sf_exp(log_pbase[i]);
+                        }
+                    }
+                }
+
+                g = gsl_ran_discrete_preproc(B, pbase);
+                h[j] = gsl_ran_discrete(rg, g);
+                gsl_ran_discrete_free(g);
+            } else {  // gamma == 1.0
+                max_cbase = cbase[0];
+                for (i = 1; i < B; i++) {
+                    if (cbase[i] >= max_cbase) {
+                        max_cbase = cbase[i];
+                    }
+                }
+                for (i = 0; i < B; i++) {
+                    if (cbase[i] == max_cbase) {
+                        pbase[i] = 1.0;
+                    } else {
+                        pbase[i] = 0.0;
+                    }
+                }
+                g = gsl_ran_discrete_preproc(B, pbase);
+                h[j] = gsl_ran_discrete(rg, g);
+                gsl_ran_discrete_free(g);
+            }
+        } else {  // K1 == 0, that is all N's
+            h[j] = B;
+        }
+        dk1 += cbase[h[j]];
+    }
+    return (double)dk1 / (double)countbases;
+}
+
+void sample_hap(cnode* cn)
+{
+
+    rnode* tr;
+    unsigned int i, j, tot_reads;
+    gsl_ran_discrete_t* g;
+    double b1, b2;
+
+    double max_log_pbase;
+    int max_cbase;
+    unsigned int base_id;
+
+#ifdef DEBUG
+    printf("Haplotype %i is\n", cn->ci);
+#endif
+
+    for (j = 0; j < J; j++) {
+
+        tot_reads = 0;
+        for (i = 0; i < B; i++) {
+            cbase[i] = 0;
+            pbase[i] = 0.0;
+        }
+
+        tr = cn->rlist;
+        while (tr != NULL) {  // correct for missing data
+            if (r[readtable2[tr->ri]->mindex][j] < B) {
+                cbase[r[readtable2[tr->ri]->mindex][j]] += readtable2[tr->ri]->weight;
+                // cbase[r[readtable2[tr->ri]->mindex][j]] ++;
+                // cbase[r[tr->ri][j]]++;
+                tot_reads += readtable2[tr->ri]->weight;
+                // tot_reads++;
+            }
+            tr = tr->next;
+        }
+
+        b1 = theta;
+        b2 = (1. - theta) / ((double)B - 1);
+
+        if (b1 == 0.0) {
+            printf("# There is something wrong with THETA ( == 0.0)\n");
+            exit(EXIT_FAILURE);
+        }
+
+        if (b1 != 1.0) {
+            for (i = 0; i < B; i++) {
+                if (tot_reads > 0) {  // base is not N: sample from reads in the cluster
+                    log_pbase[i] =
+                        cbase[i] * gsl_sf_log(b1) + (tot_reads - cbase[i]) * gsl_sf_log(b2);
+                } else  // base is N: sample from all reads
+                    log_pbase[i] = ftable[j][i] * gsl_sf_log(b1) +
+                                   (ftable_sum[j] - ftable[j][i]) * gsl_sf_log(b2);
+            }
+            max_log_pbase = log_pbase[0];
+            base_id = 0;
+            for (i = 1; i < B; i++) {
+                if (log_pbase[i] > max_log_pbase) {
+                    max_log_pbase = log_pbase[i];
+                    base_id = i;
+                }
+            }
+            for (i = 0; i < B; i++) {
+                if (i == base_id) {
+                    pbase[i] = 1.0;
+                } else {
+                    log_pbase[i] -= max_log_pbase;
+                    if (log_pbase[i] < double_threshold_min) {
+                        pbase[i] = 0.0;
+                    } else {
+                        // cout<<"log_pbase["<<i<<"] = "<<log_pbase[i]<<endl;
+                        pbase[i] = gsl_sf_exp(log_pbase[i]);
+                    }
+                }
+            }
+
+            g = gsl_ran_discrete_preproc(B, pbase);
+            cn->h[j] = gsl_ran_discrete(rg, g);
+            gsl_ran_discrete_free(g);
+        } else {                  // theta == 1.0
+            if (tot_reads > 0) {  // base not N: sample from reads in cluster.
+                max_cbase = cbase[0];
+                base_id = 0;
+                for (i = 1; i < B; i++) {
+                    if (cbase[i] >= max_cbase) {
+                        max_cbase = cbase[i];
+                        base_id = i;
+                    }
+                }
+                cn->h[j] = base_id;
+            } else {  // missing data: sample from all reads.
+                max_cbase = ftable[j][0];
+                base_id = 0;
+                for (i = 1; i < B; i++) {
+                    if (ftable[j][i] >= max_cbase) {
+                        max_cbase = ftable[j][i];
+                        base_id = i;
+                    }
+                }
+                cn->h[j] = base_id;
+            }
+        }
+
+/*
     else{ // tot_reads == 0
       //cn->h[j] = h[j]; // equals to the reference
       //cn->h[j] = B; // equals to N
@@ -1125,1106 +1113,1096 @@ void sample_hap(cnode* cn){
     }
     */
 #ifdef DEBUG
-    printf("%i ", cn->h[j]);
+        printf("%i ", cn->h[j]);
 #endif
-  }
-  
+    }
+
 #ifdef DEBUG
-  printf("\n");
+    printf("\n");
 #endif
 
-  return;  
+    return;
 }
 
+void check_size(const cnode* cst, unsigned int n)
+{
+    unsigned int this_n = 0;
+    ofstream err_file("error_size.log");
+    while (cst != NULL) {
+        this_n += cst->size;
+        cst = cst->next;
+    }
 
-void check_size(const cnode* cst, unsigned int n){
-  unsigned int this_n = 0;
-  ofstream err_file("error_size.log");
-  while(cst != NULL){
-    this_n += cst->size;
-    cst = cst->next;
-  }
-  
-  if(this_n != n){
-    print_stats(err_file, mxt, J);
-    printf("!!!! STOP !!!!\n");
-    printf("size is now %i\n", this_n);
-    exit(EXIT_FAILURE);
-  }
-  
-  return;
+    if (this_n != n) {
+        print_stats(err_file, mxt, J);
+        printf("!!!! STOP !!!!\n");
+        printf("size is now %i\n", this_n);
+        exit(EXIT_FAILURE);
+    }
+
+    return;
 }
 
-int count_classes(const cnode* cst){
-  unsigned int ck = 0;
-  
-  while(cst != NULL){
-    ck++;
-    cst = cst->next;
-  }
+int count_classes(const cnode* cst)
+{
+    unsigned int ck = 0;
 
-  return ck;
+    while (cst != NULL) {
+        ck++;
+        cst = cst->next;
+    }
+
+    return ck;
 }
 
-int isdna (char c){
-  int ans = (c == 'A' || c == 'C' || c == 'G' || c == 'T' ||
-	     c == 'a' || c == 'c' || c == 'g' || c == 't' ||
-	     c == 'N' || c == 'n' || c == '-');
+int isdna(char c)
+{
+    int ans = (c == 'A' || c == 'C' || c == 'G' || c == 'T' || c == 'a' || c == 'c' || c == 'g' ||
+               c == 't' || c == 'N' || c == 'n' || c == '-');
     return ans;
 }
 
-unsigned int d2i (char c){
+unsigned int d2i(char c)
+{
 
-  if(c == 'A' || c == 'a')
+    if (c == 'A' || c == 'a') return 0;
+    if (c == 'C' || c == 'c') return 1;
+    if (c == 'G' || c == 'g') return 2;
+    if (c == 'T' || c == 't') return 3;
+    if (c == '-') return 4;
+    if (c == 'N' || c == 'n')  // this stands for missing data
+        return B;
+    printf("%c not a DNA base", c);
+    exit(EXIT_FAILURE);
     return 0;
-  if(c == 'C' || c == 'c')
-    return 1;
-  if(c == 'G' || c == 'g')
-    return 2;
-  if(c == 'T' || c == 't')
-    return 3;
-  if(c == '-')
-    return 4;
-  if(c == 'N' || c == 'n') // this stands for missing data
-    return B;
-  printf("%c not a DNA base", c);
-  exit(EXIT_FAILURE);
-  return 0;
 }
 
-
-pair<int,int> seq_distance_new(int* A, crnode* B, int seq_length){
-  /* dist(A, B): Number of positions where A[i] != B[i]. If B[i] == 'N', it counts
-   *             as a match. Note that, if A[i] == B[i] == 'N', the distance is 
-   *             mistakenly reduced. The assumption is that is rare. In addition, 
+std::pair<int, int> seq_distance_new(int* A, crnode* B, int seq_length)
+{
+    /* dist(A, B): Number of positions where A[i] != B[i]. If B[i] == 'N', it counts
+   *             as a match. Note that, if A[i] == B[i] == 'N', the distance is
+   *             mistakenly reduced. The assumption is that is rare. In addition,
    *             if A[i] == 'N', it counts as a mismatch. FIRST ENTRY OF RETURNED
    *             PAIR corresponds to the hamming distance.
-   * sim(A, B):  Number of positions where A[i] == B[i]. If either A[i] == 'N' 
+   * sim(A, B):  Number of positions where A[i] == B[i]. If either A[i] == 'N'
    *             or B[i] == 'N', it counts as a mismatch. Note that, if
    *             A[i] == B[i] == 'N', it counts as match. SECOND ENTRY OF
-   *             RETURNED PAIR corresponds to the similarity. 
+   *             RETURNED PAIR corresponds to the similarity.
    */
-  pair<int,int> dist;
+    pair<int, int> dist;
 
-  for(int i=0; i<seq_length/10 + 1; ++i){
-    int X = *(A+i) ^ B->creads[i];
-    X = (X & one_int) | ((X & two_int) >> 1) | ((X & four_int) >> 2);
+    for (int i = 0; i < seq_length / 10 + 1; ++i) {
+        int X = *(A + i) ^ B->creads[i];
+        X = (X & one_int) | ((X & two_int) >> 1) | ((X & four_int) >> 2);
 
-    //Count the number of set bits (Knuth's algorithm)
+// Count the number of set bits (Knuth's algorithm)
 #ifdef HAVE_POPCNT
-    // using the POPCNT method
-    dist.first += _mm_popcnt_u64(X);
+        // using the POPCNT method
+        dist.first += _mm_popcnt_u64(X);
 #else
-    while(X) {
-        dist.first ++;
-        X &= X - 1;
-    }
+        while (X) {
+            dist.first++;
+            X &= X - 1;
+        }
 #endif
-  }
-  dist.second = seq_length - dist.first;
-  dist.first -= B->missing;
-  return dist;
+    }
+    dist.second = seq_length - dist.first;
+    dist.first -= B->missing;
+    return dist;
 }
 
-pair<int,int> seq_distance_rr(int* A, crnode* B, int seq_length){
-  /* dist(A, B): Number of positions where A[i] != B[i]. If A[i] == 'N' XOR 
-   *             B[i] == 'N', it counts as a mismatch. Note that, if 
-   *             A[i] == B[i] == 'N', it counts as a match. FIRST ENTRY OF 
+std::pair<int, int> seq_distance_rr(int* A, crnode* B, int seq_length)
+{
+    /* dist(A, B): Number of positions where A[i] != B[i]. If A[i] == 'N' XOR
+   *             B[i] == 'N', it counts as a mismatch. Note that, if
+   *             A[i] == B[i] == 'N', it counts as a match. FIRST ENTRY OF
    *             RETURNED PAIR corresponds to the hamming distance.
    * Tends to be on the conservative side, as ambiguous matches (i.e., N-to-any,
-   * but not N-to-N) are considered as mismatches. 
+   * but not N-to-N) are considered as mismatches.
    */
-  pair<int,int> dist;
+    pair<int, int> dist;
 
-  for(int i=0; i<seq_length/10 + 1; ++i){
-    int X = *(A+i) ^ B->creads[i];
-    X = (X & one_int) | ((X & two_int) >> 1) | ((X & four_int) >> 2);
+    for (int i = 0; i < seq_length / 10 + 1; ++i) {
+        int X = *(A + i) ^ B->creads[i];
+        X = (X & one_int) | ((X & two_int) >> 1) | ((X & four_int) >> 2);
 
-    // Count the number of set bits (Knuth's algorithm) 
-    /* NOTES: 1. Make sure the processor supports the instruction.
-     *        2. There are only 2^10 possible outcomes for X, a lookup-table is an 
+// Count the number of set bits (Knuth's algorithm)
+/* NOTES: 1. Make sure the processor supports the instruction.
+     *        2. There are only 2^10 possible outcomes for X, a lookup-table is an
      *         alternative.
      */
 
 #ifdef HAVE_POPCNT
-    // using the POPCNT method
-    dist.first += _mm_popcnt_u64(X);
+        // using the POPCNT method
+        dist.first += _mm_popcnt_u64(X);
 #else
-    while(X) {
-        dist.first ++;
-        X &= X - 1;
-    }
+        while (X) {
+            dist.first++;
+            X &= X - 1;
+        }
 #endif
-  }
-  return dist;
+    }
+    return dist;
 }
 
-pair<int,int> seq_distance(unsigned short int* a, unsigned short int* b,
-                                int seq_length){
-  /* dist(A, B): Number of positions where A[i] != B[i]. If either A[i] == 'N' 
-   *             or B[i] == 'N', it counts as a match. FIRST ENTRY OF RETURNED  
+std::pair<int, int> seq_distance(unsigned short int* a, unsigned short int* b, int seq_length)
+{
+    /* dist(A, B): Number of positions where A[i] != B[i]. If either A[i] == 'N'
+   *             or B[i] == 'N', it counts as a match. FIRST ENTRY OF RETURNED
    *             PAIR corresponds to the hamming distance.
    * sim(A, B):  Number of positiions where A[i] == B[i]. If either A[i] == 'N'
-   *             or B[i] == 'N', it counts as a mismatch. Note that, if 
+   *             or B[i] == 'N', it counts as a mismatch. Note that, if
    *             A[i] == B[i] == 'N' counts as mismatch. SECOND ENTRY OF RETURNED
-   *             PAIR corresponds to the similarity. 
+   *             PAIR corresponds to the similarity.
    */
-  int ns=0;
-  pair<int,int> dist;
+    int ns = 0;
+    pair<int, int> dist;
 
-  for(int i=0; i<seq_length; ++i, ++a, ++b){
-    if(*a != B && *b != B){
-      dist.first += (*a != *b);
-    }else{
-      ns++;
+    for (int i = 0; i < seq_length; ++i, ++a, ++b) {
+        if (*a != B && *b != B) {
+            dist.first += (*a != *b);
+        } else {
+            ns++;
+        }
     }
-  }
-  dist.second = seq_length - dist.first - ns;
-  return dist;
+    dist.second = seq_length - dist.first - ns;
+    return dist;
 }
 
-ssret* sample_class(unsigned int i, unsigned int step){
-  /*****************************************
-   the core of the Dirichlet process sampling 
+ssret* sample_class(unsigned int i, unsigned int step)
+{
+    /*****************************************
+   the core of the Dirichlet process sampling
   ******************************************/
-  unsigned int dist, nodist, removed = 0, sz, ll;
-  unsigned int tw;
-  pair<int,int> p;
-  //  int local_ci;
+    unsigned int dist, nodist, removed = 0, sz, ll;
+    unsigned int tw;
+    pair<int, int> p;
+//  int local_ci;
 #ifdef DEBUG
-  unsigned int j;
+    unsigned int j;
 #endif
-  double b1, b2; //, pow1, pow2;
-  cnode* to_class;
-  cnode* from_class;
-  size_t st = 0, this_class;
-  gsl_ran_discrete_t* g;
-  cnode* cn;
-  rnode* rn = NULL;
-  double max_log_P, delta_log;
-  //  unsigned int class_id;
-  //  int read_came_from_current;
-  int* temp;
-  temp = new int[J/10+1];
+    double b1, b2;  //, pow1, pow2;
+    cnode* to_class;
+    cnode* from_class;
+    size_t st = 0, this_class;
+    gsl_ran_discrete_t* g;
+    cnode* cn;
+    rnode* rn = NULL;
+    double max_log_P, delta_log;
+    //  unsigned int class_id;
+    //  int read_came_from_current;
+    int* temp;
+    temp = new int[J / 10 + 1];
 #ifdef DEBUG
-  for(removed=0; removed < q; removed++)
-    printf("c_ptr[%d]=%p\n", removed, c_ptr[removed]);
-  removed = 0;
-  printf("---------------------------------------------------\n");
-  printf("-----------> sampling class for %ith read <----------\n", i);
-  printf("---------------------------------------------------\n");
-  //  printf("------------ c_ptr = %p with size = %d\n", c_ptr[i], c_ptr[i]->size);
-  cout << "----------- mxt here is "<< mxt << "---------------------" << endl;
-  //  printf("------------- NOW STATS----------\n");
-  //  print_stats(out_file, mxt, J);
+    for (removed = 0; removed < q; removed++)
+        printf("c_ptr[%d]=%p\n", removed, c_ptr[removed]);
+    removed = 0;
+    printf("---------------------------------------------------\n");
+    printf("-----------> sampling class for %ith read <----------\n", i);
+    printf("---------------------------------------------------\n");
+    //  printf("------------ c_ptr = %p with size = %d\n", c_ptr[i], c_ptr[i]->size);
+    cout << "----------- mxt here is " << mxt << "---------------------" << endl;
+//  printf("------------- NOW STATS----------\n");
+//  print_stats(out_file, mxt, J);
 #endif
 
-  // if the class is populated only by i, remove it
+    // if the class is populated only by i, remove it
 
-  // if it's in the head
-  if(c_ptr[i] == NULL && mxt->size == 1){
-    
-    rn = mxt->next->rlist;
-    
-    while(rn != NULL){
-      c_ptr[rn->ri] = NULL;
-      rn = rn->next;
-    }
-    
-    remove_comp(&mxt);
-    removed = 1;
+    // if it's in the head
+    if (c_ptr[i] == NULL && mxt->size == 1) {
+
+        rn = mxt->next->rlist;
+
+        while (rn != NULL) {
+            c_ptr[rn->ri] = NULL;
+            rn = rn->next;
+        }
+
+        remove_comp(&mxt);
+        removed = 1;
 #ifdef DEBUG
-    printf("----------- REMOVED SIZE 1 NODE ----------\n");
+        printf("----------- REMOVED SIZE 1 NODE ----------\n");
 #endif
-  }
-  
-  // if it's not in the head
-  if(c_ptr[i] != NULL && c_ptr[i]->next->size == 1){
-    
-    // if i not in the last node update the following predecessor
-    if(c_ptr[i]->next->next != NULL){
-      
-      rn = c_ptr[i]->next->next->rlist;
-      while(rn != NULL){
-      c_ptr[rn->ri] = c_ptr[i];
-      rn = rn->next;
-      }
-      
     }
-    
-    remove_comp(&(c_ptr[i]->next));
-    removed = 1;
+
+    // if it's not in the head
+    if (c_ptr[i] != NULL && c_ptr[i]->next->size == 1) {
+
+        // if i not in the last node update the following predecessor
+        if (c_ptr[i]->next->next != NULL) {
+
+            rn = c_ptr[i]->next->next->rlist;
+            while (rn != NULL) {
+                c_ptr[rn->ri] = c_ptr[i];
+                rn = rn->next;
+            }
+        }
+
+        remove_comp(&(c_ptr[i]->next));
+        removed = 1;
 #ifdef DEBUG
-    printf("----------- REMOVED SIZE 1 NODE ----------\n");
+        printf("----------- REMOVED SIZE 1 NODE ----------\n");
 #endif
-  }
-  
-  //  log_P = (double*) realloc(log_P, st*sizeof(double));
-  //  P = (double*) realloc(P, st*sizeof(double));
-  
-  /**********************************************************
+    }
+
+    //  log_P = (double*) realloc(log_P, st*sizeof(double));
+    //  P = (double*) realloc(P, st*sizeof(double));
+
+    /**********************************************************
    run through the populated classes to assign a probability
   ***********************************************************/
-  
-  cn = mxt;
-  
-  if( cn == NULL){
-    printf("sampling classes, no classes found\n");
-    exit(EXIT_FAILURE);
-  }
-  
-  st = 0;
-  
-  b1 = theta;
-  b2 = (1. - theta)/((double)B - 1.);
 
-  if(theta == 0.0) {
-    cerr << "# There is something wrong wih THETA! ( == 0.0 )" << endl;
-    exit(EXIT_FAILURE);
-  }
-  if(gam == 0.0) {
-    cerr << "# There is something wrong with GAMMA! ( == 0.0 )" << endl;
-    exit(EXIT_FAILURE);
-  }
+    cn = mxt;
 
-  while (cn != NULL){
-    if(cn->size > 0) {
-      sz = cn->size;
-      //read_came_from_current = 0;
-      if(removed == 0){
-        if(c_ptr[i] != NULL && cn == c_ptr[i]->next) {
-          sz--;
-          //read_came_from_current = 1;
-        }
-        if(c_ptr[i] == NULL && cn == mxt) {
-          sz--;
-          //read_came_from_current = 1;
-        }
-      }
-      
-      // Sanity check
-      if(sz == 0){
-        // This component should have been removed previously, because only 
-        // consists of read i
-        cerr << "# Size of component " << cn->ci << " is zero" << endl;
+    if (cn == NULL) {
+        printf("sampling classes, no classes found\n");
         exit(EXIT_FAILURE);
-      }
-      cl_ptr[st] = cn;
+    }
 
-      tw = 0;
+    st = 0;
 
-      // Weighted component size, excluding read i if it is present in the current component
-      tw = weight_shift(cn, i, removed); //total weight of class - weight of read i if present in the class
-      if (tw == 0){
-        // This component should have been removed previously, because only 
-        // consists of read i
-        cerr << " # Weighted size of component " << cn->ci << "cannot be zero" << endl;
+    b1 = theta;
+    b2 = (1. - theta) / ((double)B - 1.);
+
+    if (theta == 0.0) {
+        cerr << "# There is something wrong wih THETA! ( == 0.0 )" << endl;
         exit(EXIT_FAILURE);
-      }
-      
-      dist = cn->rd0[i]; //seq_distance(cn->h, r[i], J);
-      nodist = cn->rd1[i];
-      
-      if(b1 != 1.0) { // theta < 1.0
-        log_P[st] = gsl_sf_log((double)tw);
-        log_P[st] += nodist * gsl_sf_log(b1);
-        log_P[st] += dist * gsl_sf_log(b2);
-        P[st] = 1.0; // all probabilities, which should change afterwards, set to 1
-      }
-      else{ // theta == 1.0, not needed
-        if (dist != 0){
-          log_P[st] = double_threshold_min - 1.0;
-          P[st] = 0.0;
+    }
+    if (gam == 0.0) {
+        cerr << "# There is something wrong with GAMMA! ( == 0.0 )" << endl;
+        exit(EXIT_FAILURE);
+    }
+
+    while (cn != NULL) {
+        if (cn->size > 0) {
+            sz = cn->size;
+            // read_came_from_current = 0;
+            if (removed == 0) {
+                if (c_ptr[i] != NULL && cn == c_ptr[i]->next) {
+                    sz--;
+                    // read_came_from_current = 1;
+                }
+                if (c_ptr[i] == NULL && cn == mxt) {
+                    sz--;
+                    // read_came_from_current = 1;
+                }
+            }
+
+            // Sanity check
+            if (sz == 0) {
+                // This component should have been removed previously, because only
+                // consists of read i
+                cerr << "# Size of component " << cn->ci << " is zero" << endl;
+                exit(EXIT_FAILURE);
+            }
+            cl_ptr[st] = cn;
+
+            tw = 0;
+
+            // Weighted component size, excluding read i if it is present in the current component
+            tw = weight_shift(
+                cn, i,
+                removed);  // total weight of class - weight of read i if present in the class
+            if (tw == 0) {
+                // This component should have been removed previously, because only
+                // consists of read i
+                cerr << " # Weighted size of component " << cn->ci << "cannot be zero" << endl;
+                exit(EXIT_FAILURE);
+            }
+
+            dist = cn->rd0[i];  // seq_distance(cn->h, r[i], J);
+            nodist = cn->rd1[i];
+
+            if (b1 != 1.0) {  // theta < 1.0
+                log_P[st] = gsl_sf_log((double)tw);
+                log_P[st] += nodist * gsl_sf_log(b1);
+                log_P[st] += dist * gsl_sf_log(b2);
+                P[st] = 1.0;  // all probabilities, which should change afterwards, set to 1
+            } else {          // theta == 1.0, not needed
+                if (dist != 0) {
+                    log_P[st] = double_threshold_min - 1.0;
+                    P[st] = 0.0;
+                } else {
+                    log_P[st] = gsl_sf_log((double)tw);
+                    P[st] = 1.0;  // same as above, P != 0 later
+                }
+            }
+        } else {
+            cerr << "------********* CN->SIZE = 0 **********----------\n";
+            P[st] = 0.0;  // all prob, which shouldn't change, set to 0
         }
-        else{
-          log_P[st] = gsl_sf_log((double)tw);
-          P[st] = 1.0; // same as above, P != 0 later
-        }	
-      }
-    }
-    else{
-      cerr << "------********* CN->SIZE = 0 **********----------\n";
-      P[st] = 0.0; // all prob, which shouldn't change, set to 0
-    }
-    
-    st++;
-    cn = cn->next;
-  }
-  // plus the newly instantiated one (h corresponds to sequence of reference
-  // haplotype)
-  conversion(temp, h, J);  
-  p = seq_distance_new(temp, readtable2[i], J);
-  delete[] temp;
-  dist = p.first;
-  nodist = p.second;
-  
-  b1 = (theta * gam) + (1. - gam)*(1. - theta)/((double)B - 1.);
-  b2 = (theta + gam + B*(1. - gam * theta) - 2.)/(gsl_sf_pow_int((double)B - 1., 2));
-  
-  if((theta == 1.0) && (gam == 1.0)) {
-    if (dist == 0){
-      log_P[st] = gsl_sf_log(alpha);
-      P[st] = 1.0;
-    }
-    else{
-      log_P[st] = double_threshold_min - 1.0;
-      P[st] = 0.0;
-    }
-  }
-  else {
-    log_P[st] = gsl_sf_log(alpha) + gsl_sf_log((double)(readtable2[i]->weight)) +  nodist * gsl_sf_log(b1) + dist * gsl_sf_log(b2);
-    P[st] = 1.0;
-  }
-  cl_ptr[st] = NULL;
-  
-  max_log_P = *max_element(log_P, log_P+st); //! renormalization
-  //  min_log_P = *min_element(log_P, log_P+st); //! renormalization
 
-  if (max_log_P >= 0)
-    delta_log = -max_log_P;//0.5 * (min_log_P + max_log_P);
-  else
-    delta_log = max_log_P;//-0.5 * (min_log_P + max_log_P);
+        st++;
+        cn = cn->next;
+    }
+    // plus the newly instantiated one (h corresponds to sequence of reference
+    // haplotype)
+    conversion(temp, h, J);
+    p = seq_distance_new(temp, readtable2[i], J);
+    delete[] temp;
+    dist = p.first;
+    nodist = p.second;
 
-  
-//   class_id = st;  
-//   for(ll=0; ll<st; ll++) {
-//     if((max_log_P == log_P[ll]) && (P[ll] > 0.0))
-//       class_id = ll;
-//   }
+    b1 = (theta * gam) + (1. - gam) * (1. - theta) / ((double)B - 1.);
+    b2 = (theta + gam + B * (1. - gam * theta) - 2.) / (gsl_sf_pow_int((double)B - 1., 2));
 
-  for(ll=0; ll<=st; ll++) {
-    if(P[ll] > 0.0) {      
-      log_P[ll] += delta_log;
-      if(log_P[ll] < double_threshold_min)
-        P[ll] = DBL_MIN;
-      else if (log_P[ll] > double_threshold_max)
-        P[ll] = DBL_MAX;
-      else {
-        P[ll] = gsl_sf_exp(log_P[ll]);
-      }
-    }// else P[i] = 0, from above
-  }
-  
+    if ((theta == 1.0) && (gam == 1.0)) {
+        if (dist == 0) {
+            log_P[st] = gsl_sf_log(alpha);
+            P[st] = 1.0;
+        } else {
+            log_P[st] = double_threshold_min - 1.0;
+            P[st] = 0.0;
+        }
+    } else {
+        log_P[st] = gsl_sf_log(alpha) + gsl_sf_log((double)(readtable2[i]->weight)) +
+                    nodist * gsl_sf_log(b1) + dist * gsl_sf_log(b2);
+        P[st] = 1.0;
+    }
+    cl_ptr[st] = NULL;
+
+    max_log_P = *max_element(log_P, log_P + st);  //! renormalization
+    //  min_log_P = *min_element(log_P, log_P+st); //! renormalization
+
+    if (max_log_P >= 0)
+        delta_log = -max_log_P;  // 0.5 * (min_log_P + max_log_P);
+    else
+        delta_log = max_log_P;  //-0.5 * (min_log_P + max_log_P);
+
+    //   class_id = st;
+    //   for(ll=0; ll<st; ll++) {
+    //     if((max_log_P == log_P[ll]) && (P[ll] > 0.0))
+    //       class_id = ll;
+    //   }
+
+    for (ll = 0; ll <= st; ll++) {
+        if (P[ll] > 0.0) {
+            log_P[ll] += delta_log;
+            if (log_P[ll] < double_threshold_min)
+                P[ll] = DBL_MIN;
+            else if (log_P[ll] > double_threshold_max)
+                P[ll] = DBL_MAX;
+            else {
+                P[ll] = gsl_sf_exp(log_P[ll]);
+            }
+        }  // else P[i] = 0, from above
+    }
+
 #ifdef DEBUG
-  for (j=0; j<=st; j++)
-    printf("with P[%i] = %e to class %p\n", j, P[j], cl_ptr[j]);
+    for (j = 0; j <= st; j++)
+        printf("with P[%i] = %e to class %p\n", j, P[j], cl_ptr[j]);
 #endif
-  
-  g = gsl_ran_discrete_preproc(st+1, P);
-  this_class = gsl_ran_discrete(rg, g);
-  gsl_ran_discrete_free(g);
-  
+
+    g = gsl_ran_discrete_preproc(st + 1, P);
+    this_class = gsl_ran_discrete(rg, g);
+    gsl_ran_discrete_free(g);
+
 #ifdef DEBUG
-  printf ("extracted class is = %lu\n", this_class);
+    printf("extracted class is = %lu\n", this_class);
 #endif
-  
-  from_class = (c_ptr[i] != NULL) ? c_ptr[i]->next : mxt;
-  to_class = cl_ptr[this_class];
 
+    from_class = (c_ptr[i] != NULL) ? c_ptr[i]->next : mxt;
+    to_class = cl_ptr[this_class];
 
-  /***************************************
+    /***************************************
     move the read to the extracted class
   ****************************************/
 
-  if( removed == 0 ){
-    
-    if ( from_class == to_class ){
-#ifdef DEBUG
-      printf ("from %p to itself\n", from_class);
-#endif
-      
-      //      free(P);
-      //      free(cl_ptr);
-      
-      
-      res->untouched = 1;
-      res->proposed = 0;
-      res->to_class = to_class;
-      return res;
-    }
-    
-    else if ( to_class != NULL){
-#ifdef DEBUG
-      printf("moving the read from %p to %p\n", from_class, to_class);
-#endif
-      
-      c_ptr[i] = c_ptr[ to_class->rlist->ri ]; // predecessor is taken from the already present read
-      move_read(i, &from_class, &to_class);
-      (from_class->size)--;
-      (to_class->size)++;
-      from_class->weight -= readtable2[i]->weight;
-      to_class->weight += readtable2[i]->weight;
-      
-      //      free(P);
-      //      free(cl_ptr);
-      
-      
-      res->untouched = 0;
-      res->proposed = 0;
-      res->to_class = to_class;
-      return res;
-    }
-    
-    else if (to_class == NULL){
-#ifdef DEBUG    
-      printf("moving %i to a new class from %p\n", i, from_class);
-#endif
-      
-      remove_read( search_read(&from_class->rlist, i) );
-      (from_class->size)--;
-      from_class->weight -= readtable2[i]->weight;
+    if (removed == 0) {
 
-      add_comp(&mxt, &hst, lowest_free, 1, NULL, NULL, NULL, NULL, J, step, record);
-      
-      lowest_free++;
-      
-      add_read(&mxt->rlist, i);
-      mxt->weight = readtable2[i]->weight;
-      
-      mxt->h = (unsigned short int*) malloc(J * sizeof(unsigned short int));
-      sample_hap(mxt);
-      temp = new int[J/10 + 1];
-      conversion(temp, mxt->h, J);
-   
-      mxt->rd0 = (unsigned short int*) malloc(q * sizeof(unsigned short int));
-      mxt->rd1 = (unsigned short int*) malloc(q * sizeof(unsigned short int));
-      for (ll=0; ll < q; ll++){
-        p = seq_distance_new(temp, readtable2[ll], J);
-        //p = seq_distance(mxt->h, r[ll], J);
-        mxt->rd0[ll] = p.first;
-        mxt->rd1[ll] = p.second;
-      }
-      delete[] temp;
-      c_ptr[i] = NULL;
-      
-      rn = mxt->next->rlist;
-      
-      // Sanity check - there should have been at least one component before 
-      // adding a new one
-      if(rn == NULL){
-        printf("STOP!!! There should be something\n");
-        exit(21);
-      }
-      
-      while (rn != NULL){
-       c_ptr[rn->ri] = mxt;
-       rn = rn->next;
-      }
-      
-      //      free(P);
-      //      free(cl_ptr);
-      
-      
-      res->untouched = 0;
-      res->proposed = 1;
-      res->to_class = mxt;
-      return res;
-    }
-    
-  }
-  
-  else if (removed == 1){
+        if (from_class == to_class) {
 #ifdef DEBUG
-    printf("moving having removed\n");
+            printf("from %p to itself\n", from_class);
 #endif
-    if (to_class != NULL){
-      add_read(&to_class->rlist, i);
 
-      (to_class->size)++;
-      to_class->weight += readtable2[i]->weight;
-      c_ptr[i] = c_ptr[ to_class->rlist->next->ri ];
-      
-      
-      res->untouched = 0;
-      res->proposed = 0;
-      res->to_class = to_class;
+            //      free(P);
+            //      free(cl_ptr);
+
+            res->untouched = 1;
+            res->proposed = 0;
+            res->to_class = to_class;
+            return res;
+        }
+
+        else if (to_class != NULL) {
+#ifdef DEBUG
+            printf("moving the read from %p to %p\n", from_class, to_class);
+#endif
+
+            c_ptr[i] =
+                c_ptr[to_class->rlist->ri];  // predecessor is taken from the already present read
+            move_read(i, &from_class, &to_class);
+            (from_class->size)--;
+            (to_class->size)++;
+            from_class->weight -= readtable2[i]->weight;
+            to_class->weight += readtable2[i]->weight;
+
+            //      free(P);
+            //      free(cl_ptr);
+
+            res->untouched = 0;
+            res->proposed = 0;
+            res->to_class = to_class;
+            return res;
+        }
+
+        else if (to_class == NULL) {
+#ifdef DEBUG
+            printf("moving %i to a new class from %p\n", i, from_class);
+#endif
+
+            remove_read(search_read(&from_class->rlist, i));
+            (from_class->size)--;
+            from_class->weight -= readtable2[i]->weight;
+
+            add_comp(&mxt, &hst, lowest_free, 1, NULL, NULL, NULL, NULL, J, step, record);
+
+            lowest_free++;
+
+            add_read(&mxt->rlist, i);
+            mxt->weight = readtable2[i]->weight;
+
+            mxt->h = (unsigned short int*)malloc(J * sizeof(unsigned short int));
+            sample_hap(mxt);
+            temp = new int[J / 10 + 1];
+            conversion(temp, mxt->h, J);
+
+            mxt->rd0 = (unsigned short int*)malloc(q * sizeof(unsigned short int));
+            mxt->rd1 = (unsigned short int*)malloc(q * sizeof(unsigned short int));
+            for (ll = 0; ll < q; ll++) {
+                p = seq_distance_new(temp, readtable2[ll], J);
+                // p = seq_distance(mxt->h, r[ll], J);
+                mxt->rd0[ll] = p.first;
+                mxt->rd1[ll] = p.second;
+            }
+            delete[] temp;
+            c_ptr[i] = NULL;
+
+            rn = mxt->next->rlist;
+
+            // Sanity check - there should have been at least one component before
+            // adding a new one
+            if (rn == NULL) {
+                printf("STOP!!! There should be something\n");
+                exit(21);
+            }
+
+            while (rn != NULL) {
+                c_ptr[rn->ri] = mxt;
+                rn = rn->next;
+            }
+
+            //      free(P);
+            //      free(cl_ptr);
+
+            res->untouched = 0;
+            res->proposed = 1;
+            res->to_class = mxt;
+            return res;
+        }
+
     }
-    else if (to_class == NULL){
-      add_comp(&mxt, &hst, lowest_free, 1, NULL, NULL, NULL, NULL, J, step, record);
-      lowest_free++;
-      res->to_class = mxt;
-      c_ptr[i] = NULL;
-    
-      cn = mxt->next;
-      rn = cn->rlist;
-      while (rn != NULL){
-        c_ptr[rn->ri] = mxt;
-        rn = rn->next;
-      }
-      
-      add_read(&mxt->rlist, i);
-      mxt->weight = readtable2[i]->weight;
-    
-      mxt->h = (unsigned short int*) malloc(J * sizeof(unsigned short int));
-      sample_hap(mxt);
-      temp = new int[J/10 + 1];
-      conversion(temp, mxt->h, J);
-      
-      mxt->rd0 = (unsigned short int*) malloc(q * sizeof(unsigned short int));
-      mxt->rd1 = (unsigned short int*) malloc(q * sizeof(unsigned short int));
-      for (ll=0; ll < q; ll++){
-        p = seq_distance_new(temp, readtable2[ll], J);
-        //p = seq_distance(mxt->h, r[ll], J);
-        mxt->rd0[ll] = p.first;
-        mxt->rd1[ll] = p.second;
-      }
-      delete[] temp;
-      
-      res->untouched = 0;
-      res->proposed = 1;
-      
+
+    else if (removed == 1) {
+#ifdef DEBUG
+        printf("moving having removed\n");
+#endif
+        if (to_class != NULL) {
+            add_read(&to_class->rlist, i);
+
+            (to_class->size)++;
+            to_class->weight += readtable2[i]->weight;
+            c_ptr[i] = c_ptr[to_class->rlist->next->ri];
+
+            res->untouched = 0;
+            res->proposed = 0;
+            res->to_class = to_class;
+        } else if (to_class == NULL) {
+            add_comp(&mxt, &hst, lowest_free, 1, NULL, NULL, NULL, NULL, J, step, record);
+            lowest_free++;
+            res->to_class = mxt;
+            c_ptr[i] = NULL;
+
+            cn = mxt->next;
+            rn = cn->rlist;
+            while (rn != NULL) {
+                c_ptr[rn->ri] = mxt;
+                rn = rn->next;
+            }
+
+            add_read(&mxt->rlist, i);
+            mxt->weight = readtable2[i]->weight;
+
+            mxt->h = (unsigned short int*)malloc(J * sizeof(unsigned short int));
+            sample_hap(mxt);
+            temp = new int[J / 10 + 1];
+            conversion(temp, mxt->h, J);
+
+            mxt->rd0 = (unsigned short int*)malloc(q * sizeof(unsigned short int));
+            mxt->rd1 = (unsigned short int*)malloc(q * sizeof(unsigned short int));
+            for (ll = 0; ll < q; ll++) {
+                p = seq_distance_new(temp, readtable2[ll], J);
+                // p = seq_distance(mxt->h, r[ll], J);
+                mxt->rd0[ll] = p.first;
+                mxt->rd1[ll] = p.second;
+            }
+            delete[] temp;
+
+            res->untouched = 0;
+            res->proposed = 1;
+        }
+
+        return res;
     }
-    
+
+    fprintf(stderr, "WARNING!!! I DIDN'T SAMPLE READ %d\n", i);
+    // delete[] temp;
+
     return res;
-  }
-  
-  fprintf(stderr, "WARNING!!! I DIDN'T SAMPLE READ %d\n", i);
-  // delete[] temp;
-
-  return res; 
 }
 
+void write_assignment(unsigned int it, unsigned int new_proposed, const cnode* tn)
+{
 
-void write_assignment (unsigned int it, unsigned int new_proposed, const cnode* tn) {
-  
-  rnode* rn;
-  unsigned int j = 0, k;
-  
-  fprintf(assign, "# %d iterations\n", it-1);
-  fprintf(assign, "\n#gamma = %f\n", gam);
-  fprintf(assign, "\n#made %i new clusters\n\n", new_proposed);
-  
-  while(tn != NULL){
-    
-    rn = tn->rlist;
-    while(rn != NULL){
-      k = 0;
-      while(id[rn->ri][k] != '\n'){
-	fputc(id[rn->ri][k], assign);
-	k++;
-      }
-      fprintf(assign, " -> %i\n", j);
-      rn = rn->next;
+    rnode* rn;
+    unsigned int j = 0, k;
+
+    fprintf(assign, "# %d iterations\n", it - 1);
+    fprintf(assign, "\n#gamma = %f\n", gam);
+    fprintf(assign, "\n#made %i new clusters\n\n", new_proposed);
+
+    while (tn != NULL) {
+
+        rn = tn->rlist;
+        while (rn != NULL) {
+            k = 0;
+            while (id[rn->ri][k] != '\n') {
+                fputc(id[rn->ri][k], assign);
+                k++;
+            }
+            fprintf(assign, " -> %i\n", j);
+            rn = rn->next;
+        }
+        j++;
+        tn = tn->next;
     }
-    j++;
-    tn = tn->next;
-  }
-  
-  //  fprintf(assign, "\n");
-  fprintf(assign, "\n#final number of components = %i\n\n", j);
+
+    //  fprintf(assign, "\n");
+    fprintf(assign, "\n#final number of components = %i\n\n", j);
 }
 
-void create_history(unsigned int step){
-  // copy haplotypes from mxt to create the history
-  
-  cnode* tn;
+void create_history(unsigned int step)
+{
+    // copy haplotypes from mxt to create the history
 
-  tn = mxt;
-  while(tn != NULL){
-    add_hap(&hst, NULL, tn->ci, J, step);
-    tn->hh = hst;
-    memcpy(hst->h, tn->h, J*sizeof(unsigned short int));
-    tn = tn->next;
-  }
-  
-  return;
+    cnode* tn;
+
+    tn = mxt;
+    while (tn != NULL) {
+        add_hap(&hst, NULL, tn->ci, J, step);
+        tn->hh = hst;
+        memcpy(hst->h, tn->h, J * sizeof(unsigned short int));
+        tn = tn->next;
+    }
+
+    return;
 }
 
-void i2dna_string(char* ch, short unsigned int* h, int J){
-  // char* ca;
-  //ca = (char*) calloc(J, sizeof(char*));
-  for (int i=0; i<J; i++){
-    ch[i] = i2dna_code[h[i]];
-  }
-  return;// (string) ca;
+void i2dna_string(char* ch, short unsigned int* h, int J)
+{
+    // char* ca;
+    // ca = (char*) calloc(J, sizeof(char*));
+    for (int i = 0; i < J; i++) {
+        ch[i] = i2dna_code[h[i]];
+    }
+    return;  // (string) ca;
 }
 
-void record_conf(cnode* tn, unsigned int step){
-  //! record configuration of a single node at a single step
-  
-  rnode* tr;
-  char* ca;
-  ca = (char*) calloc(J, sizeof(char*));
-  i2dna_string(ca, tn->h, J);
-  string h = (string) ca;
-  free(ca);
-  freq_map::iterator freq_iter;
-  ++support[h]; //! support is updated
+void record_conf(cnode* tn, unsigned int step)
+{
+    //! record configuration of a single node at a single step
 
-  int tw = weight(tn);
-  
-  freq_iter = freq.find(h);
-  if(freq_iter != freq.end()){ //! freq is updated if haplotype is present
-    //freq_iter->second[step] = tn->size;
-    freq_iter->second[step] = tw;
-  }
-  else{
-    freq[h] = (int*)calloc(HISTORY, sizeof(unsigned int));
-    freq[h][step] = tw; //! freq is updated if haplotype is NOT present
-  }
+    rnode* tr;
+    char* ca;
+    ca = (char*)calloc(J, sizeof(char*));
+    i2dna_string(ca, tn->h, J);
+    string h = (string)ca;
+    free(ca);
+    freq_map::iterator freq_iter;
+    ++support[h];  //! support is updated
 
-  tr = tn->rlist;
-  while (tr != NULL){
-    read2hap[tr->ri][h]++;
-    tr = tr->next;
-  }
-  h.clear();
-  return;
+    int tw = weight(tn);
+
+    freq_iter = freq.find(h);
+    if (freq_iter != freq.end()) {  //! freq is updated if haplotype is present
+        // freq_iter->second[step] = tn->size;
+        freq_iter->second[step] = tw;
+    } else {
+        freq[h] = (int*)calloc(HISTORY, sizeof(unsigned int));
+        freq[h][step] = tw;  //! freq is updated if haplotype is NOT present
+    }
+
+    tr = tn->rlist;
+    while (tr != NULL) {
+        read2hap[tr->ri][h]++;
+        tr = tr->next;
+    }
+    h.clear();
+    return;
 }
 
-void old_record_conf(cnode* tn, unsigned int step){
-  /**
+void old_record_conf(cnode* tn, unsigned int step)
+{
+    /**
      record configuration of a single node at a single step
    */
-  pair<int,int> p;
-  rnode* rn;
-  
-  if(tn->step < step) { // if the node has been created in a previous step
-    //p = seq_distance_new(conversion(tn->h, J), conversion(tn->hh->h, J), J);
-    p = seq_distance(tn->h, tn->hh->h, J);
-    if(p.first != 0) { // if the haplotype has changed
-      add_hap(&hst, tn->hh, tn->ci, J, step);
-      memcpy(hst->h, tn->h, J*sizeof(unsigned short int)); // copy into history 
-      tn->hh = hst; // and then update
+    std::pair<int, int> p;
+    rnode* rn;
+
+    if (tn->step < step) {  // if the node has been created in a previous step
+        // p = seq_distance_new(conversion(tn->h, J), conversion(tn->hh->h, J), J);
+        p = seq_distance(tn->h, tn->hh->h, J);
+        if (p.first != 0) {  // if the haplotype has changed
+            add_hap(&hst, tn->hh, tn->ci, J, step);
+            memcpy(hst->h, tn->h, J * sizeof(unsigned short int));  // copy into history
+            tn->hh = hst;                                           // and then update
+        }
+    } else {  // update the haplotype
+        memcpy(tn->hh->h, tn->h, J * sizeof(unsigned short int));
     }
-  }else{ // update the haplotype
-    memcpy(tn->hh->h, tn->h, J*sizeof(unsigned short int));
-  }
 
-  rn = tn->rlist;
-  while(rn != NULL){
-    //    ass_hist[rn->ri][step - iter + HISTORY - 1] = tn->hh;  
-    rn = rn->next;
-  }
-  
-  return;
-}
-
-
-
-void cleanup() {
-  unsigned int i;
-  freq_map::iterator fit;
-  sup_map::iterator sit;
-
-  free(P);
-  free(log_P);
-  free(cl_ptr);
-  free(c_ptr);
-  free(pbase);
-  free(cbase);
-  free(log_pbase);
-  free(h);
-  
-  for(i=0; i<n; i++){
-    delete[] readtable[i]->creads;
-    delete[] readtable[i]->mindices;
-
-    free(readtable[i]);
-    free(r[i]);
-    free(id[i]);
-  }
-  free(readtable);
-  free(r);
-  free(id);
-
-  for (i=0; i<J; i++)
-    delete[] ftable[i];
-  free(ftable);
-  
-   for(i=0; i<q; i++){
-     delete[] readtable2[i]->mindices;
-//     readtable2[i]->creads = NULL;
-//     delete[] readtable2[i]->creads;
-     free(readtable2[i]);
-   }
-   free(readtable2);
-  
-
-  support.clear();
-  
-  for ( fit=freq.begin() ; fit != freq.end(); fit++ )
-    free((*fit).second);
-  freq.clear();
-  
-  for(i=0; i<n; i++)
-    read2hap[i].clear();
-  delete read2hap;
-
-  delete[] ftable_sum;
-
-  // should maybe cleanup all nodes ...
-
-}
-
-
-int compare(const void* a, const void* b) {
-  unsigned int i=0;
-  unsigned short int *h1, *h2;
-  
-  h1 = *(unsigned short int**)a;
-  h2 = *(unsigned short int**)b;
-
-  for(i=0; i<J; i++) {
-    if (*h1 != *h2) {
-      return *h1 - *h2;
+    rn = tn->rlist;
+    while (rn != NULL) {
+        //    ass_hist[rn->ri][step - iter + HISTORY - 1] = tn->hh;
+        rn = rn->next;
     }
-    h1++;
-    h2++;
-  }
-  return 0;
+
+    return;
 }
 
-int compare_hnss_seq(const void* a, const void* b) {
-  unsigned int i=0;
-  
-  hnode_single h1 = **(hnode_single**)a;
-  hnode_single h2 = **(hnode_single**)b;
+void cleanup()
+{
+    unsigned int i;
+    freq_map::iterator fit;
+    sup_map::iterator sit;
 
-  for(i=0; i<J; i++) {
-    if (h1.h[i] != h2.h[i]) {
-      return h1.h[i] - h2.h[i];
+    free(P);
+    free(log_P);
+    free(cl_ptr);
+    free(c_ptr);
+    free(pbase);
+    free(cbase);
+    free(log_pbase);
+    free(h);
+
+    for (i = 0; i < n; i++) {
+        delete[] readtable[i]->creads;
+        delete[] readtable[i]->mindices;
+
+        free(readtable[i]);
+        free(r[i]);
+        free(id[i]);
     }
-  }
-  return 0;
+    free(readtable);
+    free(r);
+    free(id);
+
+    for (i = 0; i < J; i++)
+        delete[] ftable[i];
+    free(ftable);
+
+    for (i = 0; i < q; i++) {
+        delete[] readtable2[i]->mindices;
+        //     readtable2[i]->creads = NULL;
+        //     delete[] readtable2[i]->creads;
+        free(readtable2[i]);
+    }
+    free(readtable2);
+
+    support.clear();
+
+    for (fit = freq.begin(); fit != freq.end(); fit++)
+        free((*fit).second);
+    freq.clear();
+
+    for (i = 0; i < n; i++)
+        read2hap[i].clear();
+    delete read2hap;
+
+    delete[] ftable_sum;
+
+    // should maybe cleanup all nodes ...
 }
 
-int compare_hnss_count(const void* a, const void* b) {
-  hnode_single h1 = **(hnode_single**)a;
-  hnode_single h2 = **(hnode_single**)b;
-  
-  return (h2.count - h1.count);
+int compare(const void* a, const void* b)
+{
+    unsigned int i = 0;
+    unsigned short int *h1, *h2;
+
+    h1 = *(unsigned short int**)a;
+    h2 = *(unsigned short int**)b;
+
+    for (i = 0; i < J; i++) {
+        if (*h1 != *h2) {
+            return *h1 - *h2;
+        }
+        h1++;
+        h2++;
+    }
+    return 0;
 }
 
+int compare_hnss_seq(const void* a, const void* b)
+{
+    unsigned int i = 0;
 
-struct invcomp{
-  //! used in multimap to store keys in descending order
-  bool operator() (int i1, int i2) const
-  {return i1>i2;}
+    hnode_single h1 = **(hnode_single**)a;
+    hnode_single h2 = **(hnode_single**)b;
+
+    for (i = 0; i < J; i++) {
+        if (h1.h[i] != h2.h[i]) {
+            return h1.h[i] - h2.h[i];
+        }
+    }
+    return 0;
+}
+
+int compare_hnss_count(const void* a, const void* b)
+{
+    hnode_single h1 = **(hnode_single**)a;
+    hnode_single h2 = **(hnode_single**)b;
+
+    return (h2.count - h1.count);
+}
+
+struct invcomp
+{
+    //! used in multimap to store keys in descending order
+    bool operator()(int i1, int i2) const { return i1 > i2; }
 };
 
-void write_posterior_files(string instr){
-  /** All the posterior information is written here 
+void write_posterior_files(string instr)
+{
+    /** All the posterior information is written here
    */
-  //  cout << "HISTORY = " << HISTORY << endl;
-  int insize = instr.rfind('.');
-  string corstr = instr.substr(0,insize).append("-cor.fas");
-  string supstr = instr.substr(0,insize).append("-support.fas");
-  string freqstr = instr.substr(0,insize).append("-freq.csv");
-  string str2;
-  int i=0, rcount=0, wcount=0;
-  float mean_freq, supp_fract;
-  //  float supp_thresh = 0.5;
-  
-  ofstream cor_file(corstr.c_str());
-  ofstream supp_file(supstr.c_str());
-  ofstream freq_file(freqstr.c_str());
-  
-  sup_map::iterator si;
-  multimap<int, string, invcomp> rev_sup; //! use a multimap to sort by value the support map
-  multimap<int, string, invcomp>::iterator ri;
-  
-  for (si = support.begin(); si != support.end(); ++si)
-    rev_sup.insert(pair<int, string>(si->second, si->first));
-  
-  // header of freq_file
-  freq_file << setfill('0');
-  freq_file << "#haplotype\tsupport";
-  for (unsigned int k=0; k<HISTORY; k++)
-    freq_file << "\treads";
-  freq_file << "\n";
-  
-  for (ri = rev_sup.begin(); ri != rev_sup.end(); ++ri){
-    supp_fract = (float)(ri->first) / (float)HISTORY;
-    
-    if (supp_fract >= 0.01){  
-      mean_freq = 0;
-      for (unsigned int k=0; k<HISTORY; k++)
-	mean_freq += freq[ri->second][k];
-      mean_freq /= HISTORY;    
-      
-      supp_file << ">hap_" << i << "|" << "posterior=" << supp_fract << " ave_reads=" << mean_freq << "\n";
-      supp_file <<  ri->second << "\n";
+    //  cout << "HISTORY = " << HISTORY << endl;
+    int insize = instr.rfind('.');
+    string corstr = instr.substr(0, insize).append("-cor.fas");
+    string supstr = instr.substr(0, insize).append("-support.fas");
+    string freqstr = instr.substr(0, insize).append("-freq.csv");
+    string str2;
+    int i = 0, rcount = 0, wcount = 0;
+    float mean_freq, supp_fract;
+    //  float supp_thresh = 0.5;
 
-      freq_file << ">hap_" << setw(5) << i << "\t" << ri->first;
-      for (unsigned int k=0; k<HISTORY; k++)
-	freq_file << "\t" << freq[ri->second][k];
-      freq_file << "\n";
-      ++i;
+    ofstream cor_file(corstr.c_str());
+    ofstream supp_file(supstr.c_str());
+    ofstream freq_file(freqstr.c_str());
+
+    sup_map::iterator si;
+    multimap<int, string, invcomp> rev_sup;  //! use a multimap to sort by value the support map
+    multimap<int, string, invcomp>::iterator ri;
+
+    for (si = support.begin(); si != support.end(); ++si)
+        rev_sup.insert(pair<int, string>(si->second, si->first));
+
+    // header of freq_file
+    freq_file << setfill('0');
+    freq_file << "#haplotype\tsupport";
+    for (unsigned int k = 0; k < HISTORY; k++)
+        freq_file << "\treads";
+    freq_file << "\n";
+
+    for (ri = rev_sup.begin(); ri != rev_sup.end(); ++ri) {
+        supp_fract = (float)(ri->first) / (float)HISTORY;
+
+        if (supp_fract >= 0.01) {
+            mean_freq = 0;
+            for (unsigned int k = 0; k < HISTORY; k++)
+                mean_freq += freq[ri->second][k];
+            mean_freq /= HISTORY;
+
+            supp_file << ">hap_" << i << "|"
+                      << "posterior=" << supp_fract << " ave_reads=" << mean_freq << "\n";
+            supp_file << ri->second << "\n";
+
+            freq_file << ">hap_" << setw(5) << i << "\t" << ri->first;
+            for (unsigned int k = 0; k < HISTORY; k++)
+                freq_file << "\t" << freq[ri->second][k];
+            freq_file << "\n";
+            ++i;
+        }
     }
-    
-  }
-  
-  for(unsigned int readi = 0; readi < q; readi++){
-    rev_sup.clear(); // reuse the multimap
-    for (si = read2hap[readi].begin(); si != read2hap[readi].end(); ++si)
-      rev_sup.insert(pair<int, string>(si->second, si->first));
-    
-    ri = rev_sup.begin();
-    for(wcount = 0; wcount < readtable2[readi]->weight; wcount++){
-      cor_file << id[readtable2[readi]->mindices[wcount]] << "|posterior=" << float(ri->first)/HISTORY << "\n";
-      cor_file << ri->second << "\n";
+
+    for (unsigned int readi = 0; readi < q; readi++) {
+        rev_sup.clear();  // reuse the multimap
+        for (si = read2hap[readi].begin(); si != read2hap[readi].end(); ++si)
+            rev_sup.insert(pair<int, string>(si->second, si->first));
+
+        ri = rev_sup.begin();
+        for (wcount = 0; wcount < readtable2[readi]->weight; wcount++) {
+            cor_file << id[readtable2[readi]->mindices[wcount]]
+                     << "|posterior=" << float(ri->first) / HISTORY << "\n";
+            cor_file << ri->second << "\n";
+        }
+        rcount++;
     }
-    rcount++;
-  }
-  
-  return;
+
+    return;
 }
 
-double setfinalhaplotype(unsigned int i)  {
-  unsigned int j,k;
-  int hap; //last haplotype
-  pair<int,int> p;
-  double quality;
-  
-  // sort lexicographically the haplotypes
-  if(i==0) {
-    haplotypes = (unsigned short int**)calloc(HISTORY, sizeof(unsigned short int*));
-    for(k=0; k<HISTORY; k++) {
-      haplotypes[k] = (unsigned short int*)calloc(J, sizeof(unsigned short int));
-    }
-    ch = (int*)calloc(HISTORY,sizeof(int));
-  }
-  
-  //  for(k=0; k<HISTORY; k++)
-  //    memcpy(haplotypes[k], ass_hist[i][k]->h, J*sizeof(unsigned short int));
-  
-  
-  qsort(haplotypes, HISTORY, sizeof(unsigned short int*), compare);
-  // qsort returns haplotype (pointers to the ascending sorted haplotypes)
+double setfinalhaplotype(unsigned int i)
+{
+    unsigned int j, k;
+    int hap;  // last haplotype
+    pair<int, int> p;
+    double quality;
 
-  
-  hap = 0;
-  ch[0] = 1;
-  
-  for(k = 1; k < HISTORY; k++) {
-    //p = seq_distance_new(conversion(haplotypes[k-1], J), conversion(haplotypes[k], J), J);
-    p = seq_distance(haplotypes[k-1], haplotypes[k], J);
-    
-    if (p.first == 0 ) {
-      ch[hap] += 1;
-      
-    }else{
-      hap = k;
-      ch[hap] = 1;
+    // sort lexicographically the haplotypes
+    if (i == 0) {
+        haplotypes = (unsigned short int**)calloc(HISTORY, sizeof(unsigned short int*));
+        for (k = 0; k < HISTORY; k++) {
+            haplotypes[k] = (unsigned short int*)calloc(J, sizeof(unsigned short int));
+        }
+        ch = (int*)calloc(HISTORY, sizeof(int));
     }
-    
-  }
 
-  int max = 0;
-  for(k=0; k<HISTORY; k++) {
-    if (ch[k] >= max){
-      max = ch[k];
-      hap = k;
+    //  for(k=0; k<HISTORY; k++)
+    //    memcpy(haplotypes[k], ass_hist[i][k]->h, J*sizeof(unsigned short int));
+
+    qsort(haplotypes, HISTORY, sizeof(unsigned short int*), compare);
+    // qsort returns haplotype (pointers to the ascending sorted haplotypes)
+
+    hap = 0;
+    ch[0] = 1;
+
+    for (k = 1; k < HISTORY; k++) {
+        // p = seq_distance_new(conversion(haplotypes[k-1], J), conversion(haplotypes[k], J), J);
+        p = seq_distance(haplotypes[k - 1], haplotypes[k], J);
+
+        if (p.first == 0) {
+            ch[hap] += 1;
+
+        } else {
+            hap = k;
+            ch[hap] = 1;
+        }
     }
-  }
-  
-  quality = ch[hap]/(double)HISTORY;
 
-  for(j=0;j<J;j++)
-    if(r[i][j] < B)
-      r[i][j] = haplotypes[hap][j];
-  
-  if(i == n-1) {
-    for(k=0;k<HISTORY;k++) {
-      free(haplotypes[k]);
+    int max = 0;
+    for (k = 0; k < HISTORY; k++) {
+        if (ch[k] >= max) {
+            max = ch[k];
+            hap = k;
+        }
     }
-    free(haplotypes);
-    free(ch);
-  }
-  
-  return quality;
 
+    quality = ch[hap] / (double)HISTORY;
+
+    for (j = 0; j < J; j++)
+        if (r[i][j] < B) r[i][j] = haplotypes[hap][j];
+
+    if (i == n - 1) {
+        for (k = 0; k < HISTORY; k++) {
+            free(haplotypes[k]);
+        }
+        free(haplotypes);
+        free(ch);
+    }
+
+    return quality;
 }
 
+void write_haplotype_frequencies(char* filename, unsigned int hcount)
+{
+    FILE* fp;
+    unsigned int i, j, hap, running_sum = 0;
+    float rnh_ratio = 0.0;
+    hnode_single** all_haplo;
+    std::pair<int, int> p;
 
-void write_haplotype_frequencies(char* filename, unsigned int hcount) {
-  FILE* fp;
-  unsigned int i, j, hap, running_sum=0;
-  float rnh_ratio=0.0;
-  hnode_single** all_haplo;
-  pair<int,int> p;
-  
-  /*
+    /*
   int k;
   for(i=0; i<n; i++) {
     printf("read_%d\n", i);
     for(j=0; j<HISTORY; j++) {
       printf("step_%d\n", j);
       for(k=0; k<J; k++) {
-	printf("%c",i2dna_code[ass_hist[i][j]->h[k]]);
+    printf("%c",i2dna_code[ass_hist[i][j]->h[k]]);
       }
       printf("\n");
     }
       printf("\n\n");
   }
   */
-  
-  all_haplo = (hnode_single**)malloc(n*HISTORY*sizeof(hnode_single*));
-  for(i=0; i<n; i++) {
-    for(j=0; j<HISTORY; j++) {
-      all_haplo[i*HISTORY+j] = (hnode_single*)malloc(sizeof(hnode_single));
-      all_haplo[i*HISTORY+j]->h = (unsigned short int*)malloc(J*sizeof(unsigned short int));
-      //      all_haplo[i*HISTORY+j]->hi = ass_hist[i][j]->hi;
-      //      all_haplo[i*HISTORY+j]->step = ass_hist[i][j]->step;
-      all_haplo[i*HISTORY+j]->count = 1;
-      //      memcpy(all_haplo[i*HISTORY+j]->h, ass_hist[i][j]->h, J*sizeof(unsigned short int));
+
+    all_haplo = (hnode_single**)malloc(n * HISTORY * sizeof(hnode_single*));
+    for (i = 0; i < n; i++) {
+        for (j = 0; j < HISTORY; j++) {
+            all_haplo[i * HISTORY + j] = (hnode_single*)malloc(sizeof(hnode_single));
+            all_haplo[i * HISTORY + j]->h =
+                (unsigned short int*)malloc(J * sizeof(unsigned short int));
+            //      all_haplo[i*HISTORY+j]->hi = ass_hist[i][j]->hi;
+            //      all_haplo[i*HISTORY+j]->step = ass_hist[i][j]->step;
+            all_haplo[i * HISTORY + j]->count = 1;
+            //      memcpy(all_haplo[i*HISTORY+j]->h, ass_hist[i][j]->h, J*sizeof(unsigned short
+            //      int));
+        }
     }
-  }
-  printf("# n=%d, J=%d, HISTORY=%d\n", n, J, HISTORY);
-  printf("# n * J * HISTORY=%d\n", n*J*HISTORY);
-  /*
+    printf("# n=%d, J=%d, HISTORY=%d\n", n, J, HISTORY);
+    printf("# n * J * HISTORY=%d\n", n * J * HISTORY);
+    /*
   printf("# The number of bytes in a short int is %ld.\n", sizeof(short int));
   printf("# The number of bytes in a unsigned short int is %ld.\n", sizeof(unsigned short int));
   printf("# The number of bytes in ass_hist is %ld.\n", sizeof(ass_hist[1][1]));
   printf("# The number of bytes in all_haplo is %ld.\n", sizeof(hnode_single));
   */
-  qsort(all_haplo, n*HISTORY, sizeof(hnode_single*), compare_hnss_seq);
-  
-  hap = 0;
-  for(i=1; i<n*HISTORY; i++) {
-    //p = seq_distance_new(conversion(all_haplo[i]->h, J), conversion(all_haplo[i-1]->h, J), J);
-    p = seq_distance(all_haplo[i]->h, all_haplo[i-1]->h, J);
-    if(p.first == 0) {
-      all_haplo[hap]->count++;
-      all_haplo[i]->count = 0;
-    }else{
-      hap = i;
-    }
-  }
-  
-  qsort(all_haplo, n*HISTORY, sizeof(hnode_single**), compare_hnss_count);
-  if(hcount <= 0) {
-    hcount = n*HISTORY;
-  }
-  
-  hap=0;
-  fp = fopen(filename,"w");
-  for(i=0; i<n*HISTORY; i++) {
-    if(all_haplo[i]->count > 0) {
-      running_sum += all_haplo[i]->count;
-      fprintf(fp, ">haplotype_%04d|%.9f\n", hap, (double)(1.0*all_haplo[i]->count)/(1.0 * n * HISTORY));
-      for(j=0; j<J; j++) {
-	fprintf(fp,"%c", i2dna_code[all_haplo[i]->h[j]]);
-      }
-      fprintf(fp,"\n");
-      hap++;
-      if(hap >= hcount)
-	break;
-    }
-  }
-  fclose(fp);
-  // if (1.0*fabs(running_sum - (n*HISTORY))/(n*HISTORY) > 0.001){
-  //   printf("WATCH OUT, running_sum=%d and not %d\n", running_sum, n*HISTORY);
-  //   }
-  rnh_ratio = float(running_sum)/(n*HISTORY);
-  if (fabs(rnh_ratio - 1) > 0.001){
-    printf("WATCH OUT, running_sum=%d and not %d\n", running_sum, n*HISTORY);
+    qsort(all_haplo, n * HISTORY, sizeof(hnode_single*), compare_hnss_seq);
+
+    hap = 0;
+    for (i = 1; i < n * HISTORY; i++) {
+        // p = seq_distance_new(conversion(all_haplo[i]->h, J), conversion(all_haplo[i-1]->h, J),
+        // J);
+        p = seq_distance(all_haplo[i]->h, all_haplo[i - 1]->h, J);
+        if (p.first == 0) {
+            all_haplo[hap]->count++;
+            all_haplo[i]->count = 0;
+        } else {
+            hap = i;
+        }
     }
 
-  for(i=0; i<n*HISTORY; i++) {
-    free(all_haplo[i]->h);
-  }
-  free(all_haplo);
+    qsort(all_haplo, n * HISTORY, sizeof(hnode_single**), compare_hnss_count);
+    if (hcount <= 0) {
+        hcount = n * HISTORY;
+    }
 
+    hap = 0;
+    fp = fopen(filename, "w");
+    for (i = 0; i < n * HISTORY; i++) {
+        if (all_haplo[i]->count > 0) {
+            running_sum += all_haplo[i]->count;
+            fprintf(fp, ">haplotype_%04d|%.9f\n", hap,
+                    (double)(1.0 * all_haplo[i]->count) / (1.0 * n * HISTORY));
+            for (j = 0; j < J; j++) {
+                fprintf(fp, "%c", i2dna_code[all_haplo[i]->h[j]]);
+            }
+            fprintf(fp, "\n");
+            hap++;
+            if (hap >= hcount) break;
+        }
+    }
+    fclose(fp);
+    // if (1.0*fabs(running_sum - (n*HISTORY))/(n*HISTORY) > 0.001){
+    //   printf("WATCH OUT, running_sum=%d and not %d\n", running_sum, n*HISTORY);
+    //   }
+    rnh_ratio = float(running_sum) / (n * HISTORY);
+    if (fabs(rnh_ratio - 1) > 0.001) {
+        printf("WATCH OUT, running_sum=%d and not %d\n", running_sum, n * HISTORY);
+    }
+
+    for (i = 0; i < n * HISTORY; i++) {
+        free(all_haplo[i]->h);
+    }
+    free(all_haplo);
 }
 
-void print_stats(ofstream& out_file, const cnode* cn, unsigned int J){
-  
-  unsigned int i, j;
-  rnode* p;
-  out_file << "# -------- PRINTING STATS ---------\n";
-  if( cn == NULL)
-    out_file << "# no components in this list\n";
-  
-  while (cn != NULL){
-    
-    i=0;
-    p = cn->rlist;
-    
-    if(p == NULL)
-      out_file << "# no reads in this component\n";
-    
+void print_stats(std::ofstream& out_file, const cnode* cn, unsigned int J)
+{
+
+    unsigned int i, j;
+    rnode* p;
+    out_file << "# -------- PRINTING STATS ---------\n";
+    if (cn == NULL) out_file << "# no components in this list\n";
+
+    while (cn != NULL) {
+
+        i = 0;
+        p = cn->rlist;
+
+        if (p == NULL) out_file << "# no reads in this component\n";
+
 #ifdef DEBUG
-    if(p != NULL)
-      out_file << "# reads in the list:\t";
+        if (p != NULL) out_file << "# reads in the list:\t";
 #endif
 
-    while(p != NULL){
-      i++;
-      p = p->next;
-    }
-    
-    out_file << "\n# component " << cn->ci << " at " << (void*)cn << " has " << i << " reads size= " << cn->weight << endl;
-    out_file << "# haplotype is:\n# >h" << cn->ci <<"\n# ";
-    for(j=0; j<J; j++)
-      out_file << i2dna_code[cn->h[j]];
-    out_file << "\n\n";
+        while (p != NULL) {
+            i++;
+            p = p->next;
+        }
 
-    cn = cn->next;
-    
-  }
-  out_file << "# -------- STATS PRINTED ----------\n"; 
+        out_file << "\n# component " << cn->ci << " at " << (void*)cn << " has " << i
+                 << " reads size= " << cn->weight << std::endl;
+        out_file << "# haplotype is:\n# >h" << cn->ci << "\n# ";
+        for (j = 0; j < J; j++)
+            out_file << i2dna_code[cn->h[j]];
+        out_file << "\n\n";
+
+        cn = cn->next;
+    }
+    out_file << "# -------- STATS PRINTED ----------\n";
 }
 
-int parsecommandline(int argc, char** argv){
-// get command line parameters
-  
-  char c;
-  while((c = getopt(argc, argv,"i:j:a:t:o:m:K:k:R:c:Hh")) != -1){
-    
-    switch (c){
-    case 'i':
-      filein = optarg;
-      break;
-    case 'j':
-      iter = atoi(optarg);
-      break;
-    case 'a':
-      alpha = atof(optarg);
-      break;
-    case 't':
-      HISTORY = atoi(optarg);
-      break;
-    case 'K':
-      if(avgNK == 0.0) {
-	K = atoi(optarg);
-      }else{
-	printf("can't use -k and -K at same time.\n");
-	exit(1);
-      }
-      break;
-    case 'k':
-      if(K == 0) {
-	avgNK = atof(optarg);
-      }else{
-	printf("can't use -k and -K at same time.\n");
-	exit(1);
-      }
-      break;
-    case 'R':
-      randseed = atoi(optarg);
-      break;
-    default :
-      fprintf(stdout, "%s [options]\n"
-	      "\n"
-	      "  files\n"
-	      "\t-i <input data file>\n"
-	      "  parameters\n"
-	      "\t-j <sampling iterations>\n"
-	      "\t-a <alpha>\n"
-	      "\t-K <startvalue for number of clusters> not compat. with -k\n"
-	      "\t-k <avg. number of reads in each startcluster> not compat. with -K\n"
-	      "\t-t <history time>\n"
-	      "\t-R <randomseed>\n"
-	      "-----------------------------------------------------\n"
-	      "\t-h\t\t this help!\n", argv[0]);
-      exit(-1);
+int parsecommandline(int argc, char** argv)
+{
+    // get command line parameters
+
+    char c;
+    while ((c = getopt(argc, argv, "i:j:a:t:o:m:K:k:R:c:Hh")) != -1) {
+
+        switch (c) {
+            case 'i':
+                filein = optarg;
+                break;
+            case 'j':
+                iter = atoi(optarg);
+                break;
+            case 'a':
+                alpha = atof(optarg);
+                break;
+            case 't':
+                HISTORY = atoi(optarg);
+                break;
+            case 'K':
+                if (avgNK == 0.0) {
+                    K = atoi(optarg);
+                } else {
+                    printf("can't use -k and -K at same time.\n");
+                    exit(1);
+                }
+                break;
+            case 'k':
+                if (K == 0) {
+                    avgNK = atof(optarg);
+                } else {
+                    printf("can't use -k and -K at same time.\n");
+                    exit(1);
+                }
+                break;
+            case 'R':
+                randseed = atoi(optarg);
+                break;
+            default:
+                fprintf(stdout,
+                        "%s [options]\n"
+                        "\n"
+                        "  files\n"
+                        "\t-i <input data file>\n"
+                        "  parameters\n"
+                        "\t-j <sampling iterations>\n"
+                        "\t-a <alpha>\n"
+                        "\t-K <startvalue for number of clusters> not compat. with -k\n"
+                        "\t-k <avg. number of reads in each startcluster> not compat. with -K\n"
+                        "\t-t <history time>\n"
+                        "\t-R <randomseed>\n"
+                        "-----------------------------------------------------\n"
+                        "\t-h\t\t this help!\n",
+                        argv[0]);
+                exit(-1);
+        }
     }
-    
-  }
-  if(HISTORY > iter)HISTORY=iter;
-  if(randseed == 0) randseed = time(NULL);
-  if( (K==0) && (avgNK <= 0.0))avgNK = default_avgNK;
-  return 0;
-} // ends parsecommandline
+    if (HISTORY > iter) HISTORY = iter;
+    if (randseed == 0) randseed = time(NULL);
+    if ((K == 0) && (avgNK <= 0.0)) avgNK = default_avgNK;
+    return 0;
+}  // ends parsecommandline

--- a/src/shorah/dpm_sampler.cpp
+++ b/src/shorah/dpm_sampler.cpp
@@ -298,7 +298,7 @@ int main(int argc, char** argv)
     temp = new int[J / 10 + 1];
 
     for (k = 0; k <= iter; k++) {
-#ifdef DEBUG
+#ifndef NDEBUG
         printf("-----------------------------------------------\n");
         printf("-----------> sampling the %ith time <-----------\n", k);
         printf("-----------------------------------------------\n");
@@ -396,7 +396,7 @@ int main(int argc, char** argv)
         if (theta <= 0.0) theta = 0.0001;
 // sample_ref();    // sampling the reference every step gives strange behaviour...
 
-#ifdef DEBUG
+#ifndef NDEBUG
         std::cerr << "dt=" << dt << "\ttheta=" << theta << "\tgamma=" << gam << std::endl;
 #endif
         //    out_file("iteration\t%i\t%i\t%i\t%f\t%f\n", k+1, count_classes(mxt), tot_untouch,
@@ -767,7 +767,7 @@ void build_assignment(std::ofstream& out_file)
     // there is at least the first cluster...
     cn = mxt;
 
-#ifdef DEBUG
+#ifndef NDEBUG
     printf("cluster %d has size %d\n", cn->ci, cn->size);
 #endif
 
@@ -804,12 +804,12 @@ void build_assignment(std::ofstream& out_file)
         cn->next->rd0 = (unsigned short int*)malloc(q * sizeof(unsigned short int));
         cn->next->rd1 = (unsigned short int*)malloc(q * sizeof(unsigned short int));
 
-#ifdef DEBUG
+#ifndef NDEBUG
         printf("cluster %d has size %d\n", cn->next->ci, cn->next->size);
 #endif
 
         if (cn->next->size == 0) {
-#ifdef DEBUG
+#ifndef NDEBUG
             printf("removing some node... p=%p\n", cn->next);
 #endif
             remove_comp(&cn->next);
@@ -1016,7 +1016,7 @@ void sample_hap(cnode* cn)
     int max_cbase;
     unsigned int base_id;
 
-#ifdef DEBUG
+#ifndef NDEBUG
     printf("Haplotype %i is\n", cn->ci);
 #endif
 
@@ -1117,12 +1117,12 @@ void sample_hap(cnode* cn)
         gsl_ran_discrete_free(g);
     }
     */
-#ifdef DEBUG
+#ifndef NDEBUG
         printf("%i ", cn->h[j]);
 #endif
     }
 
-#ifdef DEBUG
+#ifndef NDEBUG
     printf("\n");
 #endif
 
@@ -1283,7 +1283,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
     unsigned int tw;
     std::pair<int, int> p;
 //  int local_ci;
-#ifdef DEBUG
+#ifndef NDEBUG
     unsigned int j;
 #endif
     double b1, b2;  //, pow1, pow2;
@@ -1298,7 +1298,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
     //  int read_came_from_current;
     int* temp;
     temp = new int[J / 10 + 1];
-#ifdef DEBUG
+#ifndef NDEBUG
     for (removed = 0; removed < q; removed++)
         printf("c_ptr[%d]=%p\n", removed, c_ptr[removed]);
     removed = 0;
@@ -1325,7 +1325,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
 
         remove_comp(&mxt);
         removed = 1;
-#ifdef DEBUG
+#ifndef NDEBUG
         printf("----------- REMOVED SIZE 1 NODE ----------\n");
 #endif
     }
@@ -1345,7 +1345,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
 
         remove_comp(&(c_ptr[i]->next));
         removed = 1;
-#ifdef DEBUG
+#ifndef NDEBUG
         printf("----------- REMOVED SIZE 1 NODE ----------\n");
 #endif
     }
@@ -1494,7 +1494,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
         }  // else P[i] = 0, from above
     }
 
-#ifdef DEBUG
+#ifndef NDEBUG
     for (j = 0; j <= st; j++)
         printf("with P[%i] = %e to class %p\n", j, P[j], cl_ptr[j]);
 #endif
@@ -1503,7 +1503,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
     this_class = gsl_ran_discrete(rg, g);
     gsl_ran_discrete_free(g);
 
-#ifdef DEBUG
+#ifndef NDEBUG
     printf("extracted class is = %lu\n", this_class);
 #endif
 
@@ -1517,7 +1517,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
     if (removed == 0) {
 
         if (from_class == to_class) {
-#ifdef DEBUG
+#ifndef NDEBUG
             printf("from %p to itself\n", from_class);
 #endif
 
@@ -1531,7 +1531,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
         }
 
         else if (to_class != NULL) {
-#ifdef DEBUG
+#ifndef NDEBUG
             printf("moving the read from %p to %p\n", from_class, to_class);
 #endif
 
@@ -1553,7 +1553,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
         }
 
         else if (to_class == NULL) {
-#ifdef DEBUG
+#ifndef NDEBUG
             printf("moving %i to a new class from %p\n", i, from_class);
 #endif
 
@@ -1610,7 +1610,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
     }
 
     else if (removed == 1) {
-#ifdef DEBUG
+#ifndef NDEBUG
         printf("moving having removed\n");
 #endif
         if (to_class != NULL) {
@@ -2129,7 +2129,7 @@ void print_stats(std::ofstream& out_file, const cnode* cn, unsigned int J)
 
         if (p == NULL) out_file << "# no reads in this component\n";
 
-#ifdef DEBUG
+#ifndef NDEBUG
         if (p != NULL) out_file << "# reads in the list:\t";
 #endif
 

--- a/src/shorah/dpm_sampler.hpp
+++ b/src/shorah/dpm_sampler.hpp
@@ -25,8 +25,9 @@
 /* variables and functions defined here
    for data structures see data_structures.hpp */
 
-using std::map;
-using std::string;
+#include <map>
+#include <string>
+#include <utility>
 
 const unsigned int B = 5;  // characters in the alphabet
 const int one_int = 153391689;
@@ -72,9 +73,9 @@ double g_noise = 0.0001;
 double* P;
 double* log_P;
 
-typedef pair<string, int> sipair;
+typedef std::pair<std::string, int> sipair;
 // bool comp_values (sipair e1, sipair e2);
-typedef map<string, int> sup_map;
+typedef std::map<std::string, int> sup_map;
 sup_map support; /*! How many times the haplotype/read is found in history*/
 
 typedef std::map<std::string, int*> freq_map;
@@ -175,6 +176,6 @@ double setfinalhaplotype(unsigned int i);
 
 void write_haplotype_frequencies(char* filename, unsigned int hcount);
 
-void write_posterior_files(string instr);
+void write_posterior_files(std::string instr);
 
 void print_stats(std::ofstream& out_file, const cnode* cn, unsigned int J);

--- a/src/shorah/dpm_sampler.hpp
+++ b/src/shorah/dpm_sampler.hpp
@@ -23,12 +23,12 @@
 */
 
 /* variables and functions defined here
-   for data structures see data_structures.h */
+   for data structures see data_structures.hpp */
 
 using std::map;
 using std::string;
 
-const unsigned int B=5; //characters in the alphabet
+const unsigned int B = 5;  // characters in the alphabet
 const int one_int = 153391689;
 const int two_int = 306783378;
 const int four_int = 613566756;
@@ -41,8 +41,8 @@ crnode** readtable;
 crnode** readtable2;
 int** ftable;
 int* ftable_sum;
-//multimap<string,int> readmap;
-//int** creads;
+// multimap<string,int> readmap;
+// int** creads;
 unsigned short int* h;
 ssret* res;
 int* res_dist;
@@ -58,8 +58,8 @@ unsigned int lowest_free = 0;
 unsigned int iter = 1000;
 unsigned int MAX_K;
 unsigned int J;
-unsigned int K = 0; //initial number of clusters
-double avgNK = 0.0; //average #reads in each startcluster, avgNK = n/K
+unsigned int K = 0;  // initial number of clusters
+double avgNK = 0.0;  // average #reads in each startcluster, avgNK = n/K
 double default_avgNK = 10.0;
 unsigned int HISTORY = 100;
 double theta = 0.90;
@@ -68,27 +68,27 @@ double eps2 = 0.001;
 double gam = 0.90;
 double alpha = 0.01;
 double g_noise = 0.0001;
-//unsigned int* c; // c[i] = k -> read i in class k
+// unsigned int* c; // c[i] = k -> read i in class k
 double* P;
 double* log_P;
 
-typedef pair <string,int> sipair;
-//bool comp_values (sipair e1, sipair e2);
-typedef map <string, int> sup_map;
+typedef pair<string, int> sipair;
+// bool comp_values (sipair e1, sipair e2);
+typedef map<string, int> sup_map;
 sup_map support; /*! How many times the haplotype/read is found in history*/
 
-typedef map <string, int*> freq_map;
+typedef std::map<std::string, int*> freq_map;
 freq_map freq; /*! How many reads had the ahplotype assigned in history*/
 
-typedef map <string, string*> ass_map;
+typedef std::map<std::string, std::string*> ass_map;
 ass_map assignment; /*! reads id assigned to the given haplotype*/
 sup_map* read2hap;
 
-cnode** cl_ptr; // class local pointer, while c_ptr is global
+cnode** cl_ptr;  // class local pointer, while c_ptr is global
 cnode** c_ptr;
 cnode* mxt = NULL;
-hnode* hst = NULL; // linked list for haplotype history, first element
-//sample_rec* sample_hist;
+hnode* hst = NULL;  // linked list for haplotype history, first element
+// sample_rec* sample_hist;
 
 FILE* assign;
 
@@ -97,7 +97,7 @@ unsigned int record = 0;
 int storagetype;
 
 unsigned short int** haplotypes;
-int *ch; //count haplotypes
+int* ch;  // count haplotypes
 
 char* haplotype_output;
 int ho_flag = 0;
@@ -107,18 +107,18 @@ FILE* fp_clustersize;
 char* clusterfile_output;
 int write_clusterfile = 0;
 
-double double_threshold_min; // will be set to = gsl_sf_log(DBL_MIN);
-double double_threshold_max; // will be set to = gsl_sf_log(DBL_MAX);
-                          // where DBL_MIN is the smallest number != 0.0, a (double) random number generator
-                         // can produce...
-                         // needed for omitting underflow-errors of gsl-functions
+double double_threshold_min;  // will be set to = gsl_sf_log(DBL_MIN);
+double double_threshold_max;  // will be set to = gsl_sf_log(DBL_MAX);
+// where DBL_MIN is the smallest number != 0.0, a (double) random number generator
+// can produce...
+// needed for omitting underflow-errors of gsl-functions
 
 // random number generator via gsl
 const gsl_rng_type* T;
-const gsl_rng* rg; /* gsl, global generator */
-const gsl_rng* urg; /* gsl, global generator for uniform */
+const gsl_rng* rg;          /* gsl, global generator */
+const gsl_rng* urg;         /* gsl, global generator for uniform */
 unsigned long randseed = 0; /* random seed, if no command line parameter
-			       -R given, set to current time */
+                   -R given, set to current time */
 
 void read_data(char* filein, std::ofstream& out_file);
 
@@ -136,13 +136,13 @@ int isdna(char c);
 
 unsigned int d2i(char c);
 
-std::pair<int,int> seq_distance_new(int* A, crnode* B, int seq_length);
+std::pair<int, int> seq_distance_new(int* A, crnode* B, int seq_length);
 
-std::pair<int,int> seq_distance_rr(int* A, crnode* B, int seq_length);
+std::pair<int, int> seq_distance_rr(int* A, crnode* B, int seq_length);
 
-std::pair<int,int> seq_distance(unsigned short int* a, unsigned short int* b, int seq_length);
+std::pair<int, int> seq_distance(unsigned short int* a, unsigned short int* b, int seq_length);
 
-ssret* sample_class(unsigned int i,unsigned int step);
+ssret* sample_class(unsigned int i, unsigned int step);
 
 void sample_hap(cnode* c);
 
@@ -152,7 +152,7 @@ void check_size(const cnode* cst, unsigned int n);
 
 int count_classes(const cnode* cst);
 
-void write_assignment (unsigned int it, unsigned int new_proposed, const cnode* tn);
+void write_assignment(unsigned int it, unsigned int new_proposed, const cnode* tn);
 
 void create_history(unsigned int k);
 
@@ -169,7 +169,7 @@ int compare_hnss_seq(const void* a, const void* b);
 
 int compare_hnss_count(const void* a, const void* b);
 
-int isnewhaplotype(hnode **p,unsigned short int *h);
+int isnewhaplotype(hnode** p, unsigned short int* h);
 
 double setfinalhaplotype(unsigned int i);
 

--- a/src/shorah/fil.cpp
+++ b/src/shorah/fil.cpp
@@ -1,208 +1,202 @@
 /******************************
-fil.c
+fil.cpp
 Kerensa McElroy
 ETH Zurich
 adapted from samtools/calDep.c
  ******************************/
-#include <stdio.h>
-#include "sam.h"
-#include "faidx.h"
-#include <map>
 #include <getopt.h>
-#include <iostream>
-#include <fstream>
-#include <string>
 #include <gsl/gsl_sf.h>
+#include <stdio.h>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <string>
+#include "faidx.h"
+#include "sam.h"
 using namespace std;
 
-typedef struct {
+typedef struct
+{
     int pos, pos1, SNP, forwM, revM, forwT, revT, maxdepth;
     double sig, pval;
     char nuc;
-    samfile_t *in;
+    samfile_t* in;
 } tmpstruct_t;
 
-//callback for bam_fetch()
-static int fetch_func(const bam1_t *b, void *data)
+// callback for bam_fetch()
+static int fetch_func(const bam1_t* b, void* data)
 {
-    bam_plbuf_t *buf = (bam_plbuf_t*)data;
-    bam_plbuf_push(b, buf); //push all reads covering variant to pileup buffer
+    bam_plbuf_t* buf = (bam_plbuf_t*)data;
+    bam_plbuf_push(b, buf);  // push all reads covering variant to pileup buffer
     return 0;
 }
 
-//callback for bam_plbuf_init()
-static int pileup_func(uint32_t tid, uint32_t pos, int n,
-                       const bam_pileup1_t *pl, void *data)
+// callback for bam_plbuf_init()
+static int pileup_func(uint32_t tid, uint32_t pos, int n, const bam_pileup1_t* pl, void* data)
 {
-    tmpstruct_t *tmp = (tmpstruct_t*)data;
-    map<char, int> st_freq_all;
-    map<char, int> st_freq_Mut;
-    st_freq_all['f']=0; //store frequencies of forward and reverse reads
-    st_freq_all['r']=0;
-    st_freq_Mut['f']=0;
-    st_freq_Mut['r']=0;
-    if ((int)pos >= tmp->pos && (int)pos < tmp->pos+1)
-    {
-        for (int i=0; i<n; i++)           //take each read in turn
+    tmpstruct_t* tmp = (tmpstruct_t*)data;
+    std::map<char, int> st_freq_all;
+    std::map<char, int> st_freq_Mut;
+    st_freq_all['f'] = 0;  // store frequencies of forward and reverse reads
+    st_freq_all['r'] = 0;
+    st_freq_Mut['f'] = 0;
+    st_freq_Mut['r'] = 0;
+    if ((int)pos >= tmp->pos && (int)pos < tmp->pos + 1) {
+        for (int i = 0; i < n; i++)  // take each read in turn
         {
             char c;
-            const bam_pileup1_t *p = pl + i;
-            if (p->indel==0 and p->is_del!=1)
-                c = bam_nt16_rev_table[bam1_seqi(bam1_seq(p->b), p->qpos)]; //get base for this read
-            else if (p->is_del==1)
+            const bam_pileup1_t* p = pl + i;
+            if (p->indel == 0 and p->is_del != 1)
+                c = bam_nt16_rev_table[bam1_seqi(bam1_seq(p->b),
+                                                 p->qpos)];  // get base for this read
+            else if (p->is_del == 1)
                 c = '-';
             else
                 c = '*';
-            if (bam1_strand(p->b)==0)    //forward read
+            if (bam1_strand(p->b) == 0)  // forward read
                 st_freq_all['f']++;
             else
-                st_freq_all['r']++;      //reverse read
-            if (c==tmp->nuc){            //base is variant
-                if (bam1_strand(p->b)==0){
-                    st_freq_Mut['f']++;  //forward read
-                    }
-                else
-                    st_freq_Mut['r']++;  //reverse read
-                }
-         }
-        double mean=(double)st_freq_all['f']/(st_freq_all['f']+st_freq_all['r']); //forward read ratio, all reads at this position
-        double fr=(double)st_freq_Mut['f']/(st_freq_Mut['f']+st_freq_Mut['r']);   //forward read ratio, only reads with variant at this position
+                st_freq_all['r']++;  // reverse read
+            if (c == tmp->nuc) {     // base is variant
+                if (bam1_strand(p->b) == 0) {
+                    st_freq_Mut['f']++;  // forward read
+                } else
+                    st_freq_Mut['r']++;  // reverse read
+            }
+        }
+        double mean = (double)st_freq_all['f'] /
+                      (st_freq_all['f'] +
+                       st_freq_all['r']);  // forward read ratio, all reads at this position
+        double fr =
+            (double)st_freq_Mut['f'] /
+            (st_freq_Mut['f'] +
+             st_freq_Mut['r']);  // forward read ratio, only reads with variant at this position
         double alpha;
         double beta;
         double sigma = tmp->sig;
         double prMut;
-        int m = st_freq_Mut['f'] + st_freq_Mut['r']; //total reads with variant
+        int m = st_freq_Mut['f'] + st_freq_Mut['r'];  // total reads with variant
         int k;
         double tail = 0.0;
-        alpha = mean / sigma;   //alpha and beta for beta binomial
+        alpha = mean / sigma;  // alpha and beta for beta binomial
         beta = (1 - mean) / sigma;
-		if (alpha < 1E-6 or beta < 1E-6){
-	        fprintf(stderr, "All reads in the same orientation?\n");
-	        return 11;
-		}
+        if (alpha < 1E-6 or beta < 1E-6) {
+            fprintf(stderr, "All reads in the same orientation?\n");
+            return 11;
+        }
         if (fr < mean) {
-            for (k = 0; k <= st_freq_Mut['f']; k++){
-                tail += gsl_sf_exp(
-                        (gsl_sf_lngamma((double)m + 1) -
-                         gsl_sf_lngamma((double)k + 1) -
-                         gsl_sf_lngamma((double)m - (double)k + 1) +
-                         gsl_sf_lngamma(1 / sigma) +
-                         gsl_sf_lngamma((double)k + (mean * (1 / sigma))) +
-                         gsl_sf_lngamma((double)m + ((1 - mean) / sigma) -
-                                        (double)k) -
-                         gsl_sf_lngamma(mean * (1 / sigma)) -
-                         gsl_sf_lngamma((1 - mean) / sigma) -
-                         gsl_sf_lngamma((double)m + (1 / sigma))
-                         )
-                                   );   //calculate cumulative distribution
-
-                }
+            for (k = 0; k <= st_freq_Mut['f']; k++) {
+                tail += gsl_sf_exp((
+                    gsl_sf_lngamma((double)m + 1) - gsl_sf_lngamma((double)k + 1) -
+                    gsl_sf_lngamma((double)m - (double)k + 1) + gsl_sf_lngamma(1 / sigma) +
+                    gsl_sf_lngamma((double)k + (mean * (1 / sigma))) +
+                    gsl_sf_lngamma((double)m + ((1 - mean) / sigma) - (double)k) -
+                    gsl_sf_lngamma(mean * (1 / sigma)) - gsl_sf_lngamma((1 - mean) / sigma) -
+                    gsl_sf_lngamma((double)m + (1 / sigma))));  // calculate cumulative distribution
             }
-        else {
+        } else {
             for (k = st_freq_Mut['f']; k <= m; k++) {
                 tail += gsl_sf_exp(
-                        (gsl_sf_lngamma((double)m + 1) -
-                         gsl_sf_lngamma((double)k + 1) -
-                         gsl_sf_lngamma((double)m - (double)k + 1) +
-                         gsl_sf_lngamma(1 / sigma) +
-                         gsl_sf_lngamma((double)k + (mean *(1 / sigma))) +
-                         gsl_sf_lngamma((double)m + ((1 - mean) / sigma) -
-                                        (double)k) -
-                         gsl_sf_lngamma(mean * (1 / sigma)) -
-                         gsl_sf_lngamma((1 - mean) / sigma) -
-                         gsl_sf_lngamma((double)m + (1 / sigma))
-                         )
-                                   ); //the other tail, if required
-
-                }
+                    (gsl_sf_lngamma((double)m + 1) - gsl_sf_lngamma((double)k + 1) -
+                     gsl_sf_lngamma((double)m - (double)k + 1) + gsl_sf_lngamma(1 / sigma) +
+                     gsl_sf_lngamma((double)k + (mean * (1 / sigma))) +
+                     gsl_sf_lngamma((double)m + ((1 - mean) / sigma) - (double)k) -
+                     gsl_sf_lngamma(mean * (1 / sigma)) - gsl_sf_lngamma((1 - mean) / sigma) -
+                     gsl_sf_lngamma((double)m + (1 / sigma))));  // the other tail, if required
             }
-        tmp->forwM=st_freq_Mut['f'];
-        tmp->revM=st_freq_Mut['r'];
-        tmp->forwT=st_freq_all['f'];
-        tmp->revT=st_freq_all['r'];
-        prMut=tail*2; //two sided test
-        if (prMut>1)
-            prMut=1;
-        tmp->pval=prMut; //p value
-      }
+        }
+        tmp->forwM = st_freq_Mut['f'];
+        tmp->revM = st_freq_Mut['r'];
+        tmp->forwT = st_freq_all['f'];
+        tmp->revT = st_freq_all['r'];
+        prMut = tail * 2;  // two sided test
+        if (prMut > 1) prMut = 1;
+        tmp->pval = prMut;  // p value
+    }
     return 0;
 }
 
-//main
-int main(int argc, char *argv[])
+// main
+int main(int argc, char* argv[])
 {
     tmpstruct_t tmp;
     int c = 0;
-    bam_index_t *idx;
-	int amplicon = 0;
-    while((c=getopt(argc, argv, "b:v:x:a"))!=EOF){
-        switch(c){
-			case 'b':
-            	tmp.in = samopen(optarg, "rb", 0);
-				idx = bam_index_load(optarg);
-				break;
-			case 'v':
-            	tmp.sig = atof(optarg);
-				break;
+    bam_index_t* idx;
+    int amplicon = 0;
+    while ((c = getopt(argc, argv, "b:v:x:a")) != EOF) {
+        switch (c) {
+            case 'b':
+                tmp.in = samopen(optarg, "rb", 0);
+                idx = bam_index_load(optarg);
+                break;
+            case 'v':
+                tmp.sig = atof(optarg);
+                break;
             case 'x':
                 tmp.maxdepth = atoi(optarg);
                 break;
-			case 'a':
-				amplicon = 1;
+            case 'a':
+                amplicon = 1;
         }
     }
-    if (tmp.in==0){
+    if (tmp.in == 0) {
         fprintf(stderr, "Failed to open BAM file %s\n", argv[1]);
         return 1;
-        }
-    if (idx==0){
+    }
+    if (idx == 0) {
         fprintf(stderr, "BAM indexing file is not available.\n");
         return 2;
     }
-    bam_plbuf_t *buf;
+    bam_plbuf_t* buf;
     buf = bam_plbuf_init(pileup_func, &tmp);
     bam_plp_set_maxcnt(buf->iter, tmp.maxdepth);
-    FILE *fl = fopen("SNV.txt","rt");
-    if (fl==NULL){
+    FILE* fl = fopen("SNV.txt", "rt");
+    if (fl == NULL) {
         fprintf(stderr, "Failed to open SNV file.\n");
         return 3;
-        }
+    }
     char chr[100], ref, var, fr1[7], fr2[7], fr3[7], p1[7], p2[7], p3[7];
     int pos, name;
     char str_buf[200];
     char reg[200];
-    char filename [50];
+    char filename[50];
     ofstream snpsOut;
     sprintf(filename, "SNVs_%f.txt", tmp.sig);
     snpsOut.open(filename, ios::out);
 
-	if (amplicon){
-		// amplicon only has one window, parses a single frequency and posterior and uses fr1 and p1 only
-		while (fgets(str_buf, 200, fl) !=NULL){
-        	if (sscanf(str_buf, "%s %d %c %c %s %s", chr, &pos, &ref, &var, fr1, p1) == 6){
-            	tmp.nuc = var;
-				sprintf(reg, "%s:%d-%d", chr, pos, pos); 
-				bam_parse_region(tmp.in->header, reg, &name, &tmp.pos, &tmp.pos1);
-				bam_fetch(tmp.in->x.bam, idx, name, tmp.pos, tmp.pos1, buf, fetch_func);
-				bam_plbuf_push(0, buf);
-				bam_plbuf_reset(buf);
-				snpsOut<<chr<<'\t'<<pos<<'\t'<<ref<<'\t'<<var<<'\t'<<fr1<<'\t'<<p1<<'\t'<<tmp.forwM<<'\t'<<tmp.revM<<'\t'<<tmp.forwT<<'\t'<<tmp.revT<<'\t'<<tmp.pval<<'\n';
-			}
-    	}
-	}
-	else{
-		while (fgets(str_buf, 200, fl) !=NULL){
-        	if (sscanf(str_buf, "%s %d %c %c %s %s %s %s %s %s", chr, &pos, &ref, &var, fr1, fr2, fr3, p1, p2, p3) == 10){
-            	tmp.nuc = var;
-				sprintf(reg, "%s:%d-%d", chr, pos, pos); 
-				bam_parse_region(tmp.in->header, reg, &name, &tmp.pos, &tmp.pos1);
-				bam_fetch(tmp.in->x.bam, idx, name, tmp.pos, tmp.pos1, buf, fetch_func);
-				bam_plbuf_push(0, buf);
-				bam_plbuf_reset(buf); 
-				snpsOut<<chr<<'\t'<<pos<<'\t'<<ref<<'\t'<<var<<'\t'<<fr1<<'\t'<<fr2<<'\t'<<fr3<<'\t'<<p1<<'\t'<<p2<<'\t'<<p3<<'\t'<<tmp.forwM<<'\t'<<tmp.revM<<'\t'<<tmp.forwT<<'\t'<<tmp.revT<<'\t'<<tmp.pval<<'\n';
-			}
-    	}
-	}
+    if (amplicon) {
+        // amplicon only has one window, parses a single frequency and posterior and uses fr1 and p1
+        // only
+        while (fgets(str_buf, 200, fl) != NULL) {
+            if (sscanf(str_buf, "%s %d %c %c %s %s", chr, &pos, &ref, &var, fr1, p1) == 6) {
+                tmp.nuc = var;
+                sprintf(reg, "%s:%d-%d", chr, pos, pos);
+                bam_parse_region(tmp.in->header, reg, &name, &tmp.pos, &tmp.pos1);
+                bam_fetch(tmp.in->x.bam, idx, name, tmp.pos, tmp.pos1, buf, fetch_func);
+                bam_plbuf_push(0, buf);
+                bam_plbuf_reset(buf);
+                snpsOut << chr << '\t' << pos << '\t' << ref << '\t' << var << '\t' << fr1 << '\t'
+                        << p1 << '\t' << tmp.forwM << '\t' << tmp.revM << '\t' << tmp.forwT << '\t'
+                        << tmp.revT << '\t' << tmp.pval << '\n';
+            }
+        }
+    } else {
+        while (fgets(str_buf, 200, fl) != NULL) {
+            if (sscanf(str_buf, "%s %d %c %c %s %s %s %s %s %s", chr, &pos, &ref, &var, fr1, fr2,
+                       fr3, p1, p2, p3) == 10) {
+                tmp.nuc = var;
+                sprintf(reg, "%s:%d-%d", chr, pos, pos);
+                bam_parse_region(tmp.in->header, reg, &name, &tmp.pos, &tmp.pos1);
+                bam_fetch(tmp.in->x.bam, idx, name, tmp.pos, tmp.pos1, buf, fetch_func);
+                bam_plbuf_push(0, buf);
+                bam_plbuf_reset(buf);
+                snpsOut << chr << '\t' << pos << '\t' << ref << '\t' << var << '\t' << fr1 << '\t'
+                        << fr2 << '\t' << fr3 << '\t' << p1 << '\t' << p2 << '\t' << p3 << '\t'
+                        << tmp.forwM << '\t' << tmp.revM << '\t' << tmp.forwT << '\t' << tmp.revT
+                        << '\t' << tmp.pval << '\n';
+            }
+        }
+    }
     snpsOut.close();
     fclose(fl);
     bam_index_destroy(idx);

--- a/src/shorah/fil.cpp
+++ b/src/shorah/fil.cpp
@@ -6,14 +6,13 @@ adapted from samtools/calDep.c
  ******************************/
 #include <getopt.h>
 #include <gsl/gsl_sf.h>
-#include <stdio.h>
+#include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <string>
 #include "faidx.h"
 #include "sam.h"
-using namespace std;
 
 typedef struct
 {
@@ -160,9 +159,9 @@ int main(int argc, char* argv[])
     char str_buf[200];
     char reg[200];
     char filename[50];
-    ofstream snpsOut;
+    std::ofstream snpsOut;
     sprintf(filename, "SNVs_%f.txt", tmp.sig);
-    snpsOut.open(filename, ios::out);
+    snpsOut.open(filename, std::ios::out);
 
     if (amplicon) {
         // amplicon only has one window, parses a single frequency and posterior and uses fr1 and p1

--- a/src/shorah/freqEst.cpp
+++ b/src/shorah/freqEst.cpp
@@ -1,6 +1,6 @@
-/*  freqEst.cc - runs the EM algorithm to estimate haplotype frequencies
+/*  freqEst.cpp - runs the EM algorithm to estimate haplotype frequencies
  *  given reads and reconstructed haplotypes
- 
+
  # Copyright 2007, 2008, 2009
  # Niko Beerenwinkel,
  # Nicholas Eriksson,
@@ -8,536 +8,540 @@
  # Lukas Geyrhofer,
  # Osvaldo Zagordi,
  # ETH Zurich
- 
+
  # This file is part of ShoRAH.
  # ShoRAH is free software: you can redistribute it and/or modify
  # it under the terms of the GNU General Public License as published by
  # the Free Software Foundation, either version 3 of the License, or
  # (at your option) any later version.
- 
+
  # ShoRAH is distributed in the hope that it will be useful,
  # but WITHOUT ANY WARRANTY; without even the implied warranty of
  # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  # GNU General Public License for more details.
- 
+
  # You should have received a copy of the GNU General Public License
  # along with ShoRAH.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <cstdlib>
-#include <iostream>
-#include <fstream>
-#include <vector>
-#include <cmath>
-#include <map>
-#include <algorithm>
 #include <unistd.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <vector>
 
 using namespace std;
 
-struct Read {
-	unsigned int pos;
-	unsigned int len;
-	string seq;
+struct Read
+{
+    unsigned int pos;
+    unsigned int len;
+    string seq;
 };
 
 // needed to sort, by Osvaldo
-typedef struct comp_class {
-  string* hap;
-  double freq;
+typedef struct comp_class
+{
+    std::string* hap;
+    double freq;
 } com_pair;
 
-bool comp_func (com_pair* pi, com_pair* pj) { return (pi->freq > pj->freq); }
+bool comp_func(com_pair* pi, com_pair* pj) { return (pi->freq > pj->freq); }
 
 //#define DEBUG
 //#define SEEPROB
 
-int CORRECTPARAM = 1;  // which definition of pr(r | h) do we use
-int SEED=1; // random seed
-int ITERMAX = 5000; // maximum iterations in EM
-double ACCURACY = .000001; // convergence for EM
-double KILLP = 0; // kill all probabilities below this
-int RUNS= 5;
+int CORRECTPARAM = 1;       // which definition of pr(r | h) do we use
+int SEED = 1;               // random seed
+int ITERMAX = 5000;         // maximum iterations in EM
+double ACCURACY = .000001;  // convergence for EM
+double KILLP = 0;           // kill all probabilities below this
+int RUNS = 5;
 int N, M;
 int unmatchingReads = 0;
 
-inline int readMatchesSomeHaplotype (Read & r, vector<string> & haplotypes) {
-	for (vector<string>::iterator  g = haplotypes.begin(); g != haplotypes.end(); ++g)
-		if (r.seq == (*g).substr(r.pos,r.len)) 
-			return 1;
-	return 0;
+static inline int readMatchesSomeHaplotype(Read& r, std::vector<std::string>& haplotypes)
+{
+    for (vector<string>::iterator g = haplotypes.begin(); g != haplotypes.end(); ++g)
+        if (r.seq == (*g).substr(r.pos, r.len)) return 1;
+    return 0;
 }
 
+void getReads(std::istream& infile, std::vector<Read>& ans, std::vector<std::string>& haplotypes)
+{
+    /*
+     * get the reads from a file/stdin
+     * FIXME: this should be much more robust
+     */
 
-void getReads (istream & infile, vector<Read>& ans, vector<string> & haplotypes) {
-	/*
-	 * get the reads from a file/stdin
-	 * FIXME: this should be much more robust
-	 */
+    Read r;
+    string t;
+    string tmp;
+    string throwaway;
 
-	Read r;
-	string t;
-	string tmp;
-	string throwaway;
+    // line of file is "pos seq"
+    while (!getline(infile, tmp, ' ').eof()) {
+        if (tmp[0] == '#') {
+            getline(infile, throwaway);
+            cerr << "Comment : " << tmp << " " << throwaway << endl;
+            continue;
+        }
+        r.pos = atoi(tmp.c_str());
+        if ((r.pos < 0)) {
+            cerr << "Error: " << r.pos << " is an invalid start position\n";
+            exit(1);
+        }
 
-	// line of file is "pos seq"
-	while(!getline(infile,tmp,' ').eof()) {
-		if (tmp[0] == '#') {
-			getline(infile,throwaway);
-			cerr << "Comment : " << tmp << " " << throwaway << endl;
-			continue;       
-		}
-		r.pos = atoi(tmp.c_str());
-		if ((r.pos < 0)) { 
-			cerr << "Error: " << r.pos << " is an invalid start position\n";
-			exit(1);
-		}
+        getline(infile, r.seq);
+        r.len = r.seq.length();
+        // cout << r.pos << " " << r.seq << endl;
 
-		getline(infile,r.seq);
-		r.len = r.seq.length();
-		//cout << r.pos << " " << r.seq << endl;
-
-		if (readMatchesSomeHaplotype(r, haplotypes)) {
-			ans.push_back(r);
-		} else {
-			unmatchingReads++;
-		}
-	}
+        if (readMatchesSomeHaplotype(r, haplotypes)) {
+            ans.push_back(r);
+        } else {
+            unmatchingReads++;
+        }
+    }
 }
 
+void getHaplotypes(std::istream& in, std::vector<std::string>& genotypesFinal)
+{
+    /* read in the list of candidate haplotypes */
+    string tmp;
+    genotypesFinal.clear();
+    vector<string> genotypes;
+    // int i = 0;
 
-void getHaplotypes (istream & in, vector<string> & genotypesFinal) {
-	/* read in the list of candidate haplotypes */
-	string tmp;
-	genotypesFinal.clear();
-	vector<string> genotypes;
-	//int i = 0;
+    // line of file is "pos seq"
+    while (!getline(in, tmp).eof()) {
+        if (tmp[0] == '#') {
+            cerr << "Comment : " << tmp << endl;
+            continue;
+        }
+        genotypes.push_back(tmp);
+        // cout << i++ << " =" << tmp << ".\n";
+    }
+    if (genotypes.size() == 0) {
+        cout << "Error, no haplotypes\n";
+        exit(1);
+    }
+    // now genotypes looks like
+    // PQITSLX
+    // .QITSSX
+    // PQITSS.
+    // So we build a consensus haplotype and fill in the .'s with the consensus
+    int seqLen = genotypes[0].size();
+    char consChar = ' ';
+    string cons;
+    for (int pos = 0; pos < seqLen; ++pos) {
+        map<char, int> col;
+        for (vector<string>::iterator g = genotypes.begin(); g != genotypes.end(); ++g) {
+            col[(*g)[pos]]++;
+        }
+        int max = -1;
+        // don't want to fill in with a '.'
+        col['.'] = -100;
+        for (map<char, int>::iterator base = col.begin(); base != col.end(); ++base) {
+            if (base->second > max) {
+                consChar = base->first;
+                max = base->second;
+            }
+        }
+        cons = cons + consChar;
+    }
+    cout << "consensus haplotype\n" << cons << endl;
 
-	// line of file is "pos seq"
-	while(!getline(in,tmp).eof()) {
-		if (tmp[0] == '#') {
-			cerr << "Comment : " << tmp << endl;
-			continue;       
-		}
-		genotypes.push_back(tmp);
-		//cout << i++ << " =" << tmp << ".\n";
-	}
-	if (genotypes.size() == 0) {
-		cout << "Error, no haplotypes\n";
-		exit(1);
-	}
-	// now genotypes looks like
-	// PQITSLX
-	// .QITSSX
-	// PQITSS.
-	// So we build a consensus haplotype and fill in the .'s with the consensus
-	int seqLen = genotypes[0].size();
-	char consChar = ' ';
-	string cons;
-	for (int pos = 0; pos < seqLen; ++pos) {
-		map<char, int> col;
-		for(vector<string>::iterator g = genotypes.begin(); g != genotypes.end(); ++g) {
-			col[(*g)[pos]]++;
-		}
-		int max = -1;
-		// don't want to fill in with a '.'
-		col['.'] = -100;
-		for(map<char, int>::iterator base = col.begin(); base != col.end(); ++base) {
-			if (base->second > max) {
-				consChar = base->first;
-				max = base->second;
-			}
-		}
-		cons = cons + consChar;
-	}
-	cout << "consensus haplotype\n" << cons << endl;
-
-	vector<int> correctionCounts (genotypes.size(), 0);
-	int tmpCount;
-	for(vector<string>::iterator g = genotypes.begin(); g != genotypes.end(); ++g) {
-		tmpCount = 0;
-		for (int pos = 0; pos < seqLen; ++pos) {
-			if ((*g)[pos] == '.') {
-				tmpCount++;
-				(*g)[pos] = cons[pos];
+    vector<int> correctionCounts(genotypes.size(), 0);
+    int tmpCount;
+    for (vector<string>::iterator g = genotypes.begin(); g != genotypes.end(); ++g) {
+        tmpCount = 0;
+        for (int pos = 0; pos < seqLen; ++pos) {
+            if ((*g)[pos] == '.') {
+                tmpCount++;
+                (*g)[pos] = cons[pos];
 #ifdef DEBUG
-				cout << "correcting . to " << cons[pos] << " in sequence " << *g << endl;
+                cout << "correcting . to " << cons[pos] << " in sequence " << *g << endl;
 #endif
-			}
-		}
-		correctionCounts.push_back(tmpCount);
-	}
-	
-	//for(vector<int>::iterator a = correctionCounts.begin(); a != correctionCounts.end(); ++a) {
-	//	cout << *a << " ";
-	//}
-	//cout << endl;
+            }
+        }
+        correctionCounts.push_back(tmpCount);
+    }
 
-	// but the genotypes might not be unique right now
-	map<string, int> uniq;
-	for(vector<string>::iterator g = genotypes.begin(); g != genotypes.end(); ++g) {
-		uniq[*g]++;
-	}
-	for(map<string, int>::iterator x = uniq.begin(); x != uniq.end(); ++x) {
+    // for(vector<int>::iterator a = correctionCounts.begin(); a != correctionCounts.end(); ++a) {
+    //	cout << *a << " ";
+    //}
+    // cout << endl;
+
+    // but the genotypes might not be unique right now
+    map<string, int> uniq;
+    for (vector<string>::iterator g = genotypes.begin(); g != genotypes.end(); ++g) {
+        uniq[*g]++;
+    }
+    for (map<string, int>::iterator x = uniq.begin(); x != uniq.end(); ++x) {
 #ifdef DEBUG
-		cout << "Haplotype was repeated " <<  x->second << " times\n";
+        cout << "Haplotype was repeated " << x->second << " times\n";
 #endif
-		genotypesFinal.push_back(x->first);
-	}
-	
+        genotypesFinal.push_back(x->first);
+    }
 }
 
-inline int match (string geno, Read r) {
-	return (r.seq == geno.substr(r.pos,r.len));
+inline int match(string geno, Read r) { return (r.seq == geno.substr(r.pos, r.len)); }
+
+inline int readsEqual(Read& r, Read& s)
+{
+    if (r.pos == s.pos) {
+        if (r.seq == s.seq) {
+            return 1;
+        }
+    }
+    return 0;
 }
 
-inline int readsEqual(Read & r, Read & s) {
-	if (r.pos == s.pos) {
-		if (r.seq == s.seq) {
-			return 1;
-		}
-	}
-	return 0;
-}
+std::vector<int> countReads(std::vector<Read>& origReads, std::vector<Read>& reads)
+{
+    // take orig reads and do
+    // %hash = (rd -> number appearing in origReads
+    // u = values(hash)
+    // reads = keys(hash)
+    //
+    int tmp;
+    for (vector<Read>::iterator r = origReads.begin(); r != origReads.end(); ++r) {
+        tmp = 1;
+        for (vector<Read>::iterator s = origReads.begin(); s != r; ++s) {
+            if (readsEqual(*r, *s)) {
+                tmp = 0;
+            }
+        }
+        if (tmp) {
+            reads.push_back(*r);
+        }
+    }
 
-vector<int> countReads (vector<Read> & origReads, vector<Read> & reads) {
-	// take orig reads and do
-	// %hash = (rd -> number appearing in origReads
-	// u = values(hash)
-	// reads = keys(hash)
-	//
-	int tmp;
-	for (vector<Read>::iterator r = origReads.begin(); r != origReads.end(); ++r) {
-		tmp = 1;
-		for (vector<Read>::iterator s = origReads.begin(); s != r; ++s) {
-			if (readsEqual(*r, *s)) {
-				tmp = 0;
-			}
-		}
-		if (tmp) {
-			reads.push_back(*r);
-		}
-	}
+    vector<int> u(reads.size(), 0);
 
-	vector<int> u(reads.size(), 0);
-
-	//for(vector<Read>::iterator r = reads.begin(); r != reads.end(); ++r) {
-	for (unsigned int i = 0 ; i < reads.size(); ++i) {
-		for (vector<Read>::iterator s = origReads.begin(); s != origReads.end(); ++s) {
-			if (readsEqual(reads.at(i), *s)) {
-				u[i]++;
-			}
-		}
-	}
+    // for(vector<Read>::iterator r = reads.begin(); r != reads.end(); ++r) {
+    for (unsigned int i = 0; i < reads.size(); ++i) {
+        for (vector<Read>::iterator s = origReads.begin(); s != origReads.end(); ++s) {
+            if (readsEqual(reads.at(i), *s)) {
+                u[i]++;
+            }
+        }
+    }
 #ifdef DEBUG
-	cout << "Started with " << origReads.size() << " reads.\n";
-	cout << reads.size() << " are unique\n";
-	cout << "Counts:\n";
-	for (unsigned int i = 0; i < u.size(); ++i) {
-		cout << u[i] << " ";
-	} 
-	cout << endl;
+    cout << "Started with " << origReads.size() << " reads.\n";
+    cout << reads.size() << " are unique\n";
+    cout << "Counts:\n";
+    for (unsigned int i = 0; i < u.size(); ++i) {
+        cout << u[i] << " ";
+    }
+    cout << endl;
 #endif
-	return u;
+    return u;
 }
 
-void Estep (vector<double> const & p, vector<vector<double> >& U, vector<vector<double> > const & Z, vector<int> const & u) {
-	// given p, fills U with expected frequencies
-	int i,j;
-	double ProbY;
-
-#ifdef DEBUG
-	cout << "Estep input: " << endl;
-	for (i = 0; i < N; ++i) {
-		cout << p[i] << " ";
-	}
-	cout << endl;
-#endif
-
-	for (i = 0; i < M; ++i) {
-		ProbY = 0;
-		for (j = 0; j < N; ++j) {
-			ProbY += Z[i][j] * p[j];
-	//		cout << "ProbY = " << ProbY << endl;
-		}
-		for (j = 0; j < N; ++j) {
-	//		cout << "U[i][j] = " << u[i] << " " << Z[i][j] << " " << p[j] << " " << ProbY << endl;
-			U[i][j] = u[i]* ((Z[i][j] * p[j]) / ProbY);
-		}
-	}
-//	cout << "Estep output: " << endl;
-//	for (i = 0; i < M; ++i) {
-//		for (j = 0; j < N; ++j) {
-//			cout << U[i][j] << " ";
-//		} 
-//		cout << endl;
-//	}
-
-}
-
-void Mstep (vector<double> & p, vector<vector<double> > const & U) {
-	vector<double> v(N,0);
-	double m = 0;
-	int i,j;
-
-	for (j = 0; j < N; ++j) {
-		//cout << "." <<  v[j] << ".\n";
-		for (i = 0; i < M; ++i) {
-		//	cout << U[i][j] << " \n";
-			v[j] += U[i][j];
-		}
-		m += v[j];
-	}
-
-	for (j = 0; j < N; ++j) {
-		p[j] = v[j] / m;
-	}
+void Estep(std::vector<double> const& p, std::vector<std::vector<double> >& U,
+           std::vector<std::vector<double> > const& Z, std::vector<int> const& u)
+{
+    // given p, fills U with expected frequencies
+    int i, j;
+    double ProbY;
 
 #ifdef DEBUG
-	for (j = 0; j < N; ++j) {
-		cout << p[j] << " ";
-	}
-	cout << endl;
+    cout << "Estep input: " << endl;
+    for (i = 0; i < N; ++i) {
+        cout << p[i] << " ";
+    }
+    cout << endl;
 #endif
 
+    for (i = 0; i < M; ++i) {
+        ProbY = 0;
+        for (j = 0; j < N; ++j) {
+            ProbY += Z[i][j] * p[j];
+            //		cout << "ProbY = " << ProbY << endl;
+        }
+        for (j = 0; j < N; ++j) {
+            //		cout << "U[i][j] = " << u[i] << " " << Z[i][j] << " " << p[j] << " " << ProbY <<
+            // endl;
+            U[i][j] = u[i] * ((Z[i][j] * p[j]) / ProbY);
+        }
+    }
+    //	cout << "Estep output: " << endl;
+    //	for (i = 0; i < M; ++i) {
+    //		for (j = 0; j < N; ++j) {
+    //			cout << U[i][j] << " ";
+    //		}
+    //		cout << endl;
+    //	}
 }
 
-double logLike (vector<double> & p,vector<vector<double> > const & Z, vector<int> const & u) {
-	int i,j;
+void Mstep(std::vector<double>& p, std::vector<std::vector<double> > const& U)
+{
+    vector<double> v(N, 0);
+    double m = 0;
+    int i, j;
 
-	double ell = 0;
-	double Prob_Y;
-	for (i= 0; i < M; i++) {
-		Prob_Y = 0;
-		for (j= 0; j < N; j++) {
-			Prob_Y += Z[i][j] * p[j];
-		}
-		if (Prob_Y > 0) {
-			ell += (u[i] * log(Prob_Y));
-		}
-	}
-	return ell;
-}
+    for (j = 0; j < N; ++j) {
+        // cout << "." <<  v[j] << ".\n";
+        for (i = 0; i < M; ++i) {
+            //	cout << U[i][j] << " \n";
+            v[j] += U[i][j];
+        }
+        m += v[j];
+    }
 
-void round(vector<double> & p) {
-	for (vector<double>::iterator i = p.begin(); i != p.end(); ++i) {
-		if ((*i) < KILLP) 
-			*i = 0;
-	}
-}
-
-double EM (vector<double> & newP, vector<vector<double> > const & Z, vector<int> const & u) {
-	double sum = 0;
-	double newEll = 0;
-	vector<double> p(N,0);
-	vector<vector<double> > U(M,vector<double>(N,0));
-	double ell = 0; 
-	int iter = 0;
-	int j;
-
-	for (j = 0; j < N; ++j) {
-		p[j] = rand();
-		sum += p[j];
-	}
-	for (j = 0; j < N; ++j) {
-		p[j] = p[j] / sum;
-	}
+    for (j = 0; j < N; ++j) {
+        p[j] = v[j] / m;
+    }
 
 #ifdef DEBUG
-	for (j = 0; j < N; ++j) {
-		cout << p[j] << " ";
-	}
-	cout << endl;
+    for (j = 0; j < N; ++j) {
+        cout << p[j] << " ";
+    }
+    cout << endl;
+#endif
+}
+
+double logLike(std::vector<double>& p, std::vector<std::vector<double> > const& Z,
+               std::vector<int> const& u)
+{
+    int i, j;
+
+    double ell = 0;
+    double Prob_Y;
+    for (i = 0; i < M; i++) {
+        Prob_Y = 0;
+        for (j = 0; j < N; j++) {
+            Prob_Y += Z[i][j] * p[j];
+        }
+        if (Prob_Y > 0) {
+            ell += (u[i] * log(Prob_Y));
+        }
+    }
+    return ell;
+}
+
+void round(std::vector<double>& p)
+{
+    for (vector<double>::iterator i = p.begin(); i != p.end(); ++i) {
+        if ((*i) < KILLP) *i = 0;
+    }
+}
+
+double EM(std::vector<double>& newP, std::vector<std::vector<double> > const& Z,
+          std::vector<int> const& u)
+{
+    double sum = 0;
+    double newEll = 0;
+    vector<double> p(N, 0);
+    vector<vector<double> > U(M, vector<double>(N, 0));
+    double ell = 0;
+    int iter = 0;
+    int j;
+
+    for (j = 0; j < N; ++j) {
+        p[j] = rand();
+        sum += p[j];
+    }
+    for (j = 0; j < N; ++j) {
+        p[j] = p[j] / sum;
+    }
+
+#ifdef DEBUG
+    for (j = 0; j < N; ++j) {
+        cout << p[j] << " ";
+    }
+    cout << endl;
 #endif
 
-	while (((iter <= 2) || (abs(ell - newEll) > ACCURACY)) && (iter < ITERMAX)) {
-		if (iter > 0) {
-			round(newP);
-			p = newP;
-			ell = newEll;
-		}
+    while (((iter <= 2) || (abs(ell - newEll) > ACCURACY)) && (iter < ITERMAX)) {
+        if (iter > 0) {
+            round(newP);
+            p = newP;
+            ell = newEll;
+        }
 
-		Estep(p, U, Z, u); //  fills U
-		Mstep(newP,U); // fills p
-		newEll = logLike(newP,Z,u);
+        Estep(p, U, Z, u);  //  fills U
+        Mstep(newP, U);     // fills p
+        newEll = logLike(newP, Z, u);
 
-
-		// Print out some stats
-		if (iter%100 == 50 || iter == 1) {
+        // Print out some stats
+        if (iter % 100 == 50 || iter == 1) {
 
 #ifdef SEEPROB
-			printf("%4d\t%f\t", iter,newEll);
+            printf("%4d\t%f\t", iter, newEll);
 
-			for (j = 0; j < N; ++j) {
-				if (p[j] > 0.05) {
-					cout << j << ":" << p[j] << " ";
-				}
-			}
-			cout << endl;
+            for (j = 0; j < N; ++j) {
+                if (p[j] > 0.05) {
+                    cout << j << ":" << p[j] << " ";
+                }
+            }
+            cout << endl;
 #else
-			printf("%4d\t%f\n", iter,newEll);
+            printf("%4d\t%f\n", iter, newEll);
 #endif
-
-
-		}
-		//printf("%.3f %.3f %.3f ", newP[0], newP[1], newP[2]);
-		//printf("%.3f %.3f %.3f ", newP[3], newP[4], newP[5]);
-		//printf("%.3f %.3f %.3f\n", newP[6], newP[7], newP[8]);
-		iter++;
-	}
-	return newEll;
+        }
+        // printf("%.3f %.3f %.3f ", newP[0], newP[1], newP[2]);
+        // printf("%.3f %.3f %.3f ", newP[3], newP[4], newP[5]);
+        // printf("%.3f %.3f %.3f\n", newP[6], newP[7], newP[8]);
+        iter++;
+    }
+    return newEll;
 }
-void help (void) {
-	cout << "Usage: freqEst -f basename [-p precision -i maxiter -r runs -h -k kill -?]\n";
-	cout << "Expects basename.read and basename.geno\n";
-	cout << "Outputs to basename.popl\n";
-	exit(1);
+void help(void)
+{
+    cout << "Usage: freqEst -f basename [-p precision -i maxiter -r runs -h -k kill -?]\n";
+    cout << "Expects basename.read and basename.geno\n";
+    cout << "Outputs to basename.popl\n";
+    exit(1);
 }
 
-int main (int argc, char **argv) {
-	int c;
-	vector<string> haplotypes;
-	vector<Read> origReads, reads;
-	string basename;
-	string filename;
-	string genotypeFilename, outfilename;
-	int i,j;
+int main(int argc, char** argv)
+{
+    int c;
+    vector<string> haplotypes;
+    vector<Read> origReads, reads;
+    string basename;
+    string filename;
+    string genotypeFilename, outfilename;
+    int i, j;
 
-	/* parse options
-	 * -f file (expect file.read file.geno)
-	 * -h                           (help)
-	 */
-	while (1) {
-		c = getopt (argc, argv, "f:h?p:i:r:k:s:");
-		if (c == -1)
-			break;
-		switch (c) {
-			case 'k':
-				KILLP = atof(optarg);
-				break;
-			case 's':
-				SEED = atoi(optarg);
-				break;
-			case 'f':
-				basename = optarg;
-				break;
-			case 'p':
-				ACCURACY = atof(optarg);
-				break;
-			case 'i':
-				ITERMAX = atoi(optarg);
-				break;
-			case 'r':
-				RUNS = atoi(optarg);
-				break;
-			case '?':
-				help();
-				break;
-			case 'h':
-				help();
-				break;
-			default:
-				help();
-		}
-	}
-	if (basename == "") {
-		help();
-	}
-	filename = basename + ".read";
-	genotypeFilename = basename + ".geno";
-	outfilename = basename + ".popl";
+    /* parse options
+     * -f file (expect file.read file.geno)
+     * -h                           (help)
+     */
+    while (1) {
+        c = getopt(argc, argv, "f:h?p:i:r:k:s:");
+        if (c == -1) break;
+        switch (c) {
+            case 'k':
+                KILLP = atof(optarg);
+                break;
+            case 's':
+                SEED = atoi(optarg);
+                break;
+            case 'f':
+                basename = optarg;
+                break;
+            case 'p':
+                ACCURACY = atof(optarg);
+                break;
+            case 'i':
+                ITERMAX = atoi(optarg);
+                break;
+            case 'r':
+                RUNS = atoi(optarg);
+                break;
+            case '?':
+                help();
+                break;
+            case 'h':
+                help();
+                break;
+            default:
+                help();
+        }
+    }
+    if (basename == "") {
+        help();
+    }
+    filename = basename + ".read";
+    genotypeFilename = basename + ".geno";
+    outfilename = basename + ".popl";
 
-	srand(SEED);
+    srand(SEED);
 
-	ifstream infile (filename.c_str());
-	ifstream ginfile(genotypeFilename.c_str());
-	if (ginfile.fail() || infile.fail()) {
-		cout << "ERROR -- can't read " << basename << ".geno or .read\n";
-		exit(1);
-	}
-	ofstream outfile(outfilename.c_str());
-	//outfile.open (outfilename.c_str());
+    ifstream infile(filename.c_str());
+    ifstream ginfile(genotypeFilename.c_str());
+    if (ginfile.fail() || infile.fail()) {
+        cout << "ERROR -- can't read " << basename << ".geno or .read\n";
+        exit(1);
+    }
+    ofstream outfile(outfilename.c_str());
+    // outfile.open (outfilename.c_str());
 
-	getHaplotypes(ginfile, haplotypes);
+    getHaplotypes(ginfile, haplotypes);
 
-	getReads(infile, origReads, haplotypes);
+    getReads(infile, origReads, haplotypes);
 
+    // uniq reads
+    vector<int> u;
+    u = countReads(origReads, reads);
 
-	// uniq reads
-	vector<int> u;
-	u = countReads(origReads, reads);
+    M = reads.size();
+    N = haplotypes.size();
 
-	M = reads.size();
-	N = haplotypes.size();
+    cout << N << " haplotypes\n" << M << " reads\n";
+    cout << "Threw out " << unmatchingReads << " unexplained reads\n";
 
-	cout << N << " haplotypes\n" << M << " reads\n";
-	cout << "Threw out " << unmatchingReads << " unexplained reads\n";
+    // count how many reads a haplotype is compat with
+    vector<int> K(N, 0);
 
-	// count how many reads a haplotype is compat with
-	vector<int> K(N,0);
+    // the M x N matrix of 0/1 incidences
+    vector<vector<int> > A(M, vector<int>(N, 0));
 
-	// the M x N matrix of 0/1 incidences
-	vector<vector<int> > A(M,vector<int>(N,0));
+    for (i = 0; i < M; ++i) {
+        for (j = 0; j < N; ++j) {
+            if (match(haplotypes[j], reads[i])) {
+                A[i][j] = 1;
+                K[j]++;
+            }
+        }
+    }
 
-	for (i = 0; i < M; ++i) {
-		for (j = 0; j < N; ++j) {
-			if (match(haplotypes[j],reads[i])) {
-				A[i][j] = 1;
-				K[j]++;
-			}
-		}
-	}
+    // my @Z;  # Z[i][j] == Prob(Y = y_i | X = x_j)
+    vector<vector<double> > Z(M, vector<double>(N, 0));
+    for (i = 0; i < M; ++i) {
+        for (j = 0; j < N; ++j) {
+            if (A[i][j] == 1) {
+                if (CORRECTPARAM) {
+                    Z[i][j] = 1.0 / 1000;
+                } else {
+                    Z[i][j] = 1.0 / K[j];
+                }
+                //				cout << "Z[i][j] = "<< Z[i][j] << endl;
+            }
+        }
+    }
 
-	//my @Z;  # Z[i][j] == Prob(Y = y_i | X = x_j)
-	vector<vector<double> > Z (M,vector<double>(N,0));
-	for (i = 0; i < M; ++i) {
-		for (j = 0; j < N; ++j) {
-			if (A[i][j] == 1) {
-				if (CORRECTPARAM) {
-					Z[i][j] = 1.0 / 1000;
-				} else {
-					Z[i][j] = 1.0 / K[j];
-				}
-				//				cout << "Z[i][j] = "<< Z[i][j] << endl;
-			}
-		}
-	}
+    vector<double> prob(N, 0);
+    vector<double> bestProb(N, 0);
+    double logL;
+    double bestL = -1e100;
 
-	vector<double> prob(N,0);
-	vector<double> bestProb(N,0);
-	double logL;
-	double bestL = -1e100;
+    for (int run = 0; run < RUNS; ++run) {
+        cout << "run " << run << endl;
+        logL = EM(prob, Z, u);
+        if (logL > bestL) {
+            bestProb = prob;
+            bestL = logL;
+        }
+    }
 
-	for (int run = 0; run < RUNS; ++run) {
-		cout << "run " << run << endl;
-		logL = EM(prob,Z,u);
-		if (logL > bestL) {
-			bestProb = prob;
-			bestL = logL;
-		}
-	}
-	
-	// sort the haplotypes by frequency before printing
-	// added by Osvaldo
-	string s6 (10, 'x');
-	com_pair** freq_hap;
-	freq_hap = (com_pair**) calloc(N, sizeof(com_pair*));
-	for (int i = 0; i < N; ++i) {
-	  freq_hap[i] = (com_pair*)calloc(1, sizeof(com_pair));
-	  freq_hap[i]->hap = &(haplotypes[i]);
-	  freq_hap[i]->freq = bestProb[i];
-	}
+    // sort the haplotypes by frequency before printing
+    // added by Osvaldo
+    std::string s6(10, 'x');
+    com_pair** freq_hap;
+    freq_hap = (com_pair**)calloc(N, sizeof(com_pair*));
+    for (int i = 0; i < N; ++i) {
+        freq_hap[i] = (com_pair*)calloc(1, sizeof(com_pair));
+        freq_hap[i]->hap = &(haplotypes[i]);
+        freq_hap[i]->freq = bestProb[i];
+    }
 
-	sort(freq_hap, freq_hap+N, comp_func);
-	
-	for (int i = 0; i < N; ++i) {
-	  if (freq_hap[i]->freq > 0)  {
-	    //outfile << ">HAP" << i << "_" << bestProb[i] <<  "\n" << haplotypes[i] << endl;
-	    outfile << ">HAP" << i << "_" <<  freq_hap[i]->freq <<  "\n" << *freq_hap[i]->hap << endl;
-	    cout << i << "\t" << freq_hap[i]->freq <<  "\t" << *freq_hap[i]->hap << endl;
-	    //cout << i << " " << freq_hap[i]->freq << endl;
-	  }
-	}
-	// The output is now sorted
-	return 0;
+    sort(freq_hap, freq_hap + N, comp_func);
+
+    for (int i = 0; i < N; ++i) {
+        if (freq_hap[i]->freq > 0) {
+            // outfile << ">HAP" << i << "_" << bestProb[i] <<  "\n" << haplotypes[i] << endl;
+            outfile << ">HAP" << i << "_" << freq_hap[i]->freq << "\n" << *freq_hap[i]->hap << endl;
+            cout << i << "\t" << freq_hap[i]->freq << "\t" << *freq_hap[i]->hap << endl;
+            // cout << i << " " << freq_hap[i]->freq << endl;
+        }
+    }
+    // The output is now sorted
+    return 0;
 }

--- a/src/shorah/freqEst.cpp
+++ b/src/shorah/freqEst.cpp
@@ -33,13 +33,11 @@
 #include <map>
 #include <vector>
 
-using namespace std;
-
 struct Read
 {
     unsigned int pos;
     unsigned int len;
-    string seq;
+    std::string seq;
 };
 
 // needed to sort, by Osvaldo
@@ -65,7 +63,7 @@ int unmatchingReads = 0;
 
 static inline int readMatchesSomeHaplotype(Read& r, std::vector<std::string>& haplotypes)
 {
-    for (vector<string>::iterator g = haplotypes.begin(); g != haplotypes.end(); ++g)
+    for (std::vector<std::string>::iterator g = haplotypes.begin(); g != haplotypes.end(); ++g)
         if (r.seq == (*g).substr(r.pos, r.len)) return 1;
     return 0;
 }
@@ -78,26 +76,26 @@ void getReads(std::istream& infile, std::vector<Read>& ans, std::vector<std::str
      */
 
     Read r;
-    string t;
-    string tmp;
-    string throwaway;
+    std::string t;
+    std::string tmp;
+    std::string throwaway;
 
     // line of file is "pos seq"
-    while (!getline(infile, tmp, ' ').eof()) {
+    while (!std::getline(infile, tmp, ' ').eof()) {
         if (tmp[0] == '#') {
-            getline(infile, throwaway);
-            cerr << "Comment : " << tmp << " " << throwaway << endl;
+            std::getline(infile, throwaway);
+            std::cerr << "Comment : " << tmp << " " << throwaway << std::endl;
             continue;
         }
         r.pos = atoi(tmp.c_str());
         if ((r.pos < 0)) {
-            cerr << "Error: " << r.pos << " is an invalid start position\n";
+            std::cerr << "Error: " << r.pos << " is an invalid start position\n";
             exit(1);
         }
 
-        getline(infile, r.seq);
+        std::getline(infile, r.seq);
         r.len = r.seq.length();
-        // cout << r.pos << " " << r.seq << endl;
+        // std::cout << r.pos << " " << r.seq << std::endl;
 
         if (readMatchesSomeHaplotype(r, haplotypes)) {
             ans.push_back(r);
@@ -110,22 +108,22 @@ void getReads(std::istream& infile, std::vector<Read>& ans, std::vector<std::str
 void getHaplotypes(std::istream& in, std::vector<std::string>& genotypesFinal)
 {
     /* read in the list of candidate haplotypes */
-    string tmp;
+    std::string tmp;
     genotypesFinal.clear();
-    vector<string> genotypes;
+    std::vector<std::string> genotypes;
     // int i = 0;
 
     // line of file is "pos seq"
-    while (!getline(in, tmp).eof()) {
+    while (!std::getline(in, tmp).eof()) {
         if (tmp[0] == '#') {
-            cerr << "Comment : " << tmp << endl;
+            std::cerr << "Comment : " << tmp << std::endl;
             continue;
         }
         genotypes.push_back(tmp);
-        // cout << i++ << " =" << tmp << ".\n";
+        // std::cout << i++ << " =" << tmp << ".\n";
     }
     if (genotypes.size() == 0) {
-        cout << "Error, no haplotypes\n";
+        std::cout << "Error, no haplotypes\n";
         exit(1);
     }
     // now genotypes looks like
@@ -135,16 +133,16 @@ void getHaplotypes(std::istream& in, std::vector<std::string>& genotypesFinal)
     // So we build a consensus haplotype and fill in the .'s with the consensus
     int seqLen = genotypes[0].size();
     char consChar = ' ';
-    string cons;
+    std::string cons;
     for (int pos = 0; pos < seqLen; ++pos) {
-        map<char, int> col;
-        for (vector<string>::iterator g = genotypes.begin(); g != genotypes.end(); ++g) {
+        std::map<char, int> col;
+        for (std::vector<std::string>::iterator g = genotypes.begin(); g != genotypes.end(); ++g) {
             col[(*g)[pos]]++;
         }
         int max = -1;
         // don't want to fill in with a '.'
         col['.'] = -100;
-        for (map<char, int>::iterator base = col.begin(); base != col.end(); ++base) {
+        for (std::map<char, int>::iterator base = col.begin(); base != col.end(); ++base) {
             if (base->second > max) {
                 consChar = base->first;
                 max = base->second;
@@ -152,43 +150,44 @@ void getHaplotypes(std::istream& in, std::vector<std::string>& genotypesFinal)
         }
         cons = cons + consChar;
     }
-    cout << "consensus haplotype\n" << cons << endl;
+    std::cout << "consensus haplotype\n" << cons << std::endl;
 
-    vector<int> correctionCounts(genotypes.size(), 0);
+    std::vector<int> correctionCounts(genotypes.size(), 0);
     int tmpCount;
-    for (vector<string>::iterator g = genotypes.begin(); g != genotypes.end(); ++g) {
+    for (std::vector<std::string>::iterator g = genotypes.begin(); g != genotypes.end(); ++g) {
         tmpCount = 0;
         for (int pos = 0; pos < seqLen; ++pos) {
             if ((*g)[pos] == '.') {
                 tmpCount++;
                 (*g)[pos] = cons[pos];
 #ifdef DEBUG
-                cout << "correcting . to " << cons[pos] << " in sequence " << *g << endl;
+                std::cout << "correcting . to " << cons[pos] << " in sequence " << *g << std::endl;
 #endif
             }
         }
         correctionCounts.push_back(tmpCount);
     }
 
-    // for(vector<int>::iterator a = correctionCounts.begin(); a != correctionCounts.end(); ++a) {
-    //	cout << *a << " ";
+    // for(std::vector<int>::iterator a = correctionCounts.begin(); a != correctionCounts.end();
+    // ++a) {
+    //	std::cout << *a << " ";
     //}
-    // cout << endl;
+    // std::cout << std::endl;
 
     // but the genotypes might not be unique right now
-    map<string, int> uniq;
-    for (vector<string>::iterator g = genotypes.begin(); g != genotypes.end(); ++g) {
+    std::map<std::string, int> uniq;
+    for (std::vector<std::string>::iterator g = genotypes.begin(); g != genotypes.end(); ++g) {
         uniq[*g]++;
     }
-    for (map<string, int>::iterator x = uniq.begin(); x != uniq.end(); ++x) {
+    for (std::map<std::string, int>::iterator x = uniq.begin(); x != uniq.end(); ++x) {
 #ifdef DEBUG
-        cout << "Haplotype was repeated " << x->second << " times\n";
+        std::cout << "Haplotype was repeated " << x->second << " times\n";
 #endif
         genotypesFinal.push_back(x->first);
     }
 }
 
-inline int match(string geno, Read r) { return (r.seq == geno.substr(r.pos, r.len)); }
+inline int match(std::string geno, Read r) { return (r.seq == geno.substr(r.pos, r.len)); }
 
 inline int readsEqual(Read& r, Read& s)
 {
@@ -208,9 +207,9 @@ std::vector<int> countReads(std::vector<Read>& origReads, std::vector<Read>& rea
     // reads = keys(hash)
     //
     int tmp;
-    for (vector<Read>::iterator r = origReads.begin(); r != origReads.end(); ++r) {
+    for (std::vector<Read>::iterator r = origReads.begin(); r != origReads.end(); ++r) {
         tmp = 1;
-        for (vector<Read>::iterator s = origReads.begin(); s != r; ++s) {
+        for (std::vector<Read>::iterator s = origReads.begin(); s != r; ++s) {
             if (readsEqual(*r, *s)) {
                 tmp = 0;
             }
@@ -220,24 +219,24 @@ std::vector<int> countReads(std::vector<Read>& origReads, std::vector<Read>& rea
         }
     }
 
-    vector<int> u(reads.size(), 0);
+    std::vector<int> u(reads.size(), 0);
 
-    // for(vector<Read>::iterator r = reads.begin(); r != reads.end(); ++r) {
+    // for(std::vector<Read>::iterator r = reads.begin(); r != reads.end(); ++r) {
     for (unsigned int i = 0; i < reads.size(); ++i) {
-        for (vector<Read>::iterator s = origReads.begin(); s != origReads.end(); ++s) {
+        for (std::vector<Read>::iterator s = origReads.begin(); s != origReads.end(); ++s) {
             if (readsEqual(reads.at(i), *s)) {
                 u[i]++;
             }
         }
     }
 #ifdef DEBUG
-    cout << "Started with " << origReads.size() << " reads.\n";
-    cout << reads.size() << " are unique\n";
-    cout << "Counts:\n";
+    std::cout << "Started with " << origReads.size() << " reads.\n";
+    std::cout << reads.size() << " are unique\n";
+    std::cout << "Counts:\n";
     for (unsigned int i = 0; i < u.size(); ++i) {
-        cout << u[i] << " ";
+        std::cout << u[i] << " ";
     }
-    cout << endl;
+    std::cout << std::endl;
 #endif
     return u;
 }
@@ -250,44 +249,46 @@ void Estep(std::vector<double> const& p, std::vector<std::vector<double> >& U,
     double ProbY;
 
 #ifdef DEBUG
-    cout << "Estep input: " << endl;
+    std::cout << "Estep input: " << std::endl;
     for (i = 0; i < N; ++i) {
-        cout << p[i] << " ";
+        std::cout << p[i] << " ";
     }
-    cout << endl;
+    std::cout << std::endl;
 #endif
 
     for (i = 0; i < M; ++i) {
         ProbY = 0;
         for (j = 0; j < N; ++j) {
             ProbY += Z[i][j] * p[j];
-            //		cout << "ProbY = " << ProbY << endl;
+            //		std::cout << "ProbY = " << ProbY << std::endl;
         }
         for (j = 0; j < N; ++j) {
-            //		cout << "U[i][j] = " << u[i] << " " << Z[i][j] << " " << p[j] << " " << ProbY <<
-            // endl;
+            //		std::cout << "U[i][j] = " << u[i] << " " << Z[i][j] << " " << p[j] << " " <<
+            // ProbY
+            //<<
+            // std::endl;
             U[i][j] = u[i] * ((Z[i][j] * p[j]) / ProbY);
         }
     }
-    //	cout << "Estep output: " << endl;
+    //	std::cout << "Estep output: " << std::endl;
     //	for (i = 0; i < M; ++i) {
     //		for (j = 0; j < N; ++j) {
-    //			cout << U[i][j] << " ";
+    //			std::cout << U[i][j] << " ";
     //		}
-    //		cout << endl;
+    //		std::cout << std::endl;
     //	}
 }
 
 void Mstep(std::vector<double>& p, std::vector<std::vector<double> > const& U)
 {
-    vector<double> v(N, 0);
+    std::vector<double> v(N, 0);
     double m = 0;
     int i, j;
 
     for (j = 0; j < N; ++j) {
-        // cout << "." <<  v[j] << ".\n";
+        // std::cout << "." <<  v[j] << ".\n";
         for (i = 0; i < M; ++i) {
-            //	cout << U[i][j] << " \n";
+            //	std::cout << U[i][j] << " \n";
             v[j] += U[i][j];
         }
         m += v[j];
@@ -299,9 +300,9 @@ void Mstep(std::vector<double>& p, std::vector<std::vector<double> > const& U)
 
 #ifdef DEBUG
     for (j = 0; j < N; ++j) {
-        cout << p[j] << " ";
+        std::cout << p[j] << " ";
     }
-    cout << endl;
+    std::cout << std::endl;
 #endif
 }
 
@@ -326,7 +327,7 @@ double logLike(std::vector<double>& p, std::vector<std::vector<double> > const& 
 
 void round(std::vector<double>& p)
 {
-    for (vector<double>::iterator i = p.begin(); i != p.end(); ++i) {
+    for (std::vector<double>::iterator i = p.begin(); i != p.end(); ++i) {
         if ((*i) < KILLP) *i = 0;
     }
 }
@@ -336,8 +337,8 @@ double EM(std::vector<double>& newP, std::vector<std::vector<double> > const& Z,
 {
     double sum = 0;
     double newEll = 0;
-    vector<double> p(N, 0);
-    vector<vector<double> > U(M, vector<double>(N, 0));
+    std::vector<double> p(N, 0);
+    std::vector<std::vector<double> > U(M, std::vector<double>(N, 0));
     double ell = 0;
     int iter = 0;
     int j;
@@ -352,12 +353,12 @@ double EM(std::vector<double>& newP, std::vector<std::vector<double> > const& Z,
 
 #ifdef DEBUG
     for (j = 0; j < N; ++j) {
-        cout << p[j] << " ";
+        std::cout << p[j] << " ";
     }
-    cout << endl;
+    std::cout << std::endl;
 #endif
 
-    while (((iter <= 2) || (abs(ell - newEll) > ACCURACY)) && (iter < ITERMAX)) {
+    while (((iter <= 2) || (std::abs(ell - newEll) > ACCURACY)) && (iter < ITERMAX)) {
         if (iter > 0) {
             round(newP);
             p = newP;
@@ -376,10 +377,10 @@ double EM(std::vector<double>& newP, std::vector<std::vector<double> > const& Z,
 
             for (j = 0; j < N; ++j) {
                 if (p[j] > 0.05) {
-                    cout << j << ":" << p[j] << " ";
+                    std::cout << j << ":" << p[j] << " ";
                 }
             }
-            cout << endl;
+            std::cout << std::endl;
 #else
             printf("%4d\t%f\n", iter, newEll);
 #endif
@@ -393,20 +394,20 @@ double EM(std::vector<double>& newP, std::vector<std::vector<double> > const& Z,
 }
 void help(void)
 {
-    cout << "Usage: freqEst -f basename [-p precision -i maxiter -r runs -h -k kill -?]\n";
-    cout << "Expects basename.read and basename.geno\n";
-    cout << "Outputs to basename.popl\n";
+    std::cout << "Usage: freqEst -f basename [-p precision -i maxiter -r runs -h -k kill -?]\n";
+    std::cout << "Expects basename.read and basename.geno\n";
+    std::cout << "Outputs to basename.popl\n";
     exit(1);
 }
 
 int main(int argc, char** argv)
 {
     int c;
-    vector<string> haplotypes;
-    vector<Read> origReads, reads;
-    string basename;
-    string filename;
-    string genotypeFilename, outfilename;
+    std::vector<std::string> haplotypes;
+    std::vector<Read> origReads, reads;
+    std::string basename;
+    std::string filename;
+    std::string genotypeFilename, outfilename;
     int i, j;
 
     /* parse options
@@ -454,13 +455,13 @@ int main(int argc, char** argv)
 
     srand(SEED);
 
-    ifstream infile(filename.c_str());
-    ifstream ginfile(genotypeFilename.c_str());
+    std::ifstream infile(filename.c_str());
+    std::ifstream ginfile(genotypeFilename.c_str());
     if (ginfile.fail() || infile.fail()) {
-        cout << "ERROR -- can't read " << basename << ".geno or .read\n";
+        std::cout << "ERROR -- can't read " << basename << ".geno or .read\n";
         exit(1);
     }
-    ofstream outfile(outfilename.c_str());
+    std::ofstream outfile(outfilename.c_str());
     // outfile.open (outfilename.c_str());
 
     getHaplotypes(ginfile, haplotypes);
@@ -468,20 +469,20 @@ int main(int argc, char** argv)
     getReads(infile, origReads, haplotypes);
 
     // uniq reads
-    vector<int> u;
+    std::vector<int> u;
     u = countReads(origReads, reads);
 
     M = reads.size();
     N = haplotypes.size();
 
-    cout << N << " haplotypes\n" << M << " reads\n";
-    cout << "Threw out " << unmatchingReads << " unexplained reads\n";
+    std::cout << N << " haplotypes\n" << M << " reads\n";
+    std::cout << "Threw out " << unmatchingReads << " unexplained reads\n";
 
     // count how many reads a haplotype is compat with
-    vector<int> K(N, 0);
+    std::vector<int> K(N, 0);
 
     // the M x N matrix of 0/1 incidences
-    vector<vector<int> > A(M, vector<int>(N, 0));
+    std::vector<std::vector<int> > A(M, std::vector<int>(N, 0));
 
     for (i = 0; i < M; ++i) {
         for (j = 0; j < N; ++j) {
@@ -493,7 +494,7 @@ int main(int argc, char** argv)
     }
 
     // my @Z;  # Z[i][j] == Prob(Y = y_i | X = x_j)
-    vector<vector<double> > Z(M, vector<double>(N, 0));
+    std::vector<std::vector<double> > Z(M, std::vector<double>(N, 0));
     for (i = 0; i < M; ++i) {
         for (j = 0; j < N; ++j) {
             if (A[i][j] == 1) {
@@ -502,18 +503,18 @@ int main(int argc, char** argv)
                 } else {
                     Z[i][j] = 1.0 / K[j];
                 }
-                //				cout << "Z[i][j] = "<< Z[i][j] << endl;
+                //				std::cout << "Z[i][j] = "<< Z[i][j] << std::endl;
             }
         }
     }
 
-    vector<double> prob(N, 0);
-    vector<double> bestProb(N, 0);
+    std::vector<double> prob(N, 0);
+    std::vector<double> bestProb(N, 0);
     double logL;
     double bestL = -1e100;
 
     for (int run = 0; run < RUNS; ++run) {
-        cout << "run " << run << endl;
+        std::cout << "run " << run << std::endl;
         logL = EM(prob, Z, u);
         if (logL > bestL) {
             bestProb = prob;
@@ -532,14 +533,15 @@ int main(int argc, char** argv)
         freq_hap[i]->freq = bestProb[i];
     }
 
-    sort(freq_hap, freq_hap + N, comp_func);
+    std::sort(freq_hap, freq_hap + N, comp_func);
 
     for (int i = 0; i < N; ++i) {
         if (freq_hap[i]->freq > 0) {
-            // outfile << ">HAP" << i << "_" << bestProb[i] <<  "\n" << haplotypes[i] << endl;
-            outfile << ">HAP" << i << "_" << freq_hap[i]->freq << "\n" << *freq_hap[i]->hap << endl;
-            cout << i << "\t" << freq_hap[i]->freq << "\t" << *freq_hap[i]->hap << endl;
-            // cout << i << " " << freq_hap[i]->freq << endl;
+            // outfile << ">HAP" << i << "_" << bestProb[i] <<  "\n" << haplotypes[i] << std::endl;
+            outfile << ">HAP" << i << "_" << freq_hap[i]->freq << "\n"
+                    << *freq_hap[i]->hap << std::endl;
+            std::cout << i << "\t" << freq_hap[i]->freq << "\t" << *freq_hap[i]->hap << std::endl;
+            // std::cout << i << " " << freq_hap[i]->freq << std::endl;
         }
     }
     // The output is now sorted

--- a/src/shorah/freqEst.cpp
+++ b/src/shorah/freqEst.cpp
@@ -49,7 +49,6 @@ typedef struct comp_class
 
 bool comp_func(com_pair* pi, com_pair* pj) { return (pi->freq > pj->freq); }
 
-//#define DEBUG
 //#define SEEPROB
 
 int CORRECTPARAM = 1;       // which definition of pr(r | h) do we use
@@ -160,7 +159,7 @@ void getHaplotypes(std::istream& in, std::vector<std::string>& genotypesFinal)
             if ((*g)[pos] == '.') {
                 tmpCount++;
                 (*g)[pos] = cons[pos];
-#ifdef DEBUG
+#ifndef NDEBUG
                 std::cout << "correcting . to " << cons[pos] << " in sequence " << *g << std::endl;
 #endif
             }
@@ -180,7 +179,7 @@ void getHaplotypes(std::istream& in, std::vector<std::string>& genotypesFinal)
         uniq[*g]++;
     }
     for (std::map<std::string, int>::iterator x = uniq.begin(); x != uniq.end(); ++x) {
-#ifdef DEBUG
+#ifndef NDEBUG
         std::cout << "Haplotype was repeated " << x->second << " times\n";
 #endif
         genotypesFinal.push_back(x->first);
@@ -229,7 +228,7 @@ std::vector<int> countReads(std::vector<Read>& origReads, std::vector<Read>& rea
             }
         }
     }
-#ifdef DEBUG
+#ifndef NDEBUG
     std::cout << "Started with " << origReads.size() << " reads.\n";
     std::cout << reads.size() << " are unique\n";
     std::cout << "Counts:\n";
@@ -248,7 +247,7 @@ void Estep(std::vector<double> const& p, std::vector<std::vector<double> >& U,
     int i, j;
     double ProbY;
 
-#ifdef DEBUG
+#ifndef NDEBUG
     std::cout << "Estep input: " << std::endl;
     for (i = 0; i < N; ++i) {
         std::cout << p[i] << " ";
@@ -298,7 +297,7 @@ void Mstep(std::vector<double>& p, std::vector<std::vector<double> > const& U)
         p[j] = v[j] / m;
     }
 
-#ifdef DEBUG
+#ifndef NDEBUG
     for (j = 0; j < N; ++j) {
         std::cout << p[j] << " ";
     }
@@ -351,7 +350,7 @@ double EM(std::vector<double>& newP, std::vector<std::vector<double> > const& Z,
         p[j] = p[j] / sum;
     }
 
-#ifdef DEBUG
+#ifndef NDEBUG
     for (j = 0; j < N; ++j) {
         std::cout << p[j] << " ";
     }


### PR DESCRIPTION
Hi @ozagordi 
some minor changes to improve the quality of the codebase.

1. Reformat the whole codebase using `clang-format` consistently. Instead of the mish-mash of tabs and spaces and pointers at type-vs-identifier, all of it is now consistent and easy to format.
2. C++ code should **never** use `using namespace std` as this completely destroys the whole purpose of namespaces and will only lead to name clashes further down the road as C and C++ evolve. For this, I have fully qualified all `std::` identifiers.
3. Always use `<cXYZ>` headers instead of `<XYZ.h>` headers, as the former are proper C++ headers whereas the latter are C headers.
4. Fixed a minor mistake due to unconditionally including the `nmmintrin.h` header, even when _POPCNT_ doesn't work (for instance when using the ancient Apple GCC 4.2.1).
5. Use absence of `NDEBUG` to enable debugging output. This is more standard as it is an ISO C++ macro.