### PR TITLE
handle weird chr in fasta headers - fix issue #32

### DIFF
--- a/src/cpp/b2w.cpp
+++ b/src/cpp/b2w.cpp
@@ -243,8 +243,11 @@ int main(int argc, char* argv[])
                     rLen[j] = 0;
                 }
                 tmp.rLen = rLen;
-                sprintf(filename, "w-%s-%d-%d.reads.fas",  // read window filename
+                sprintf(filename, "w-%s-%u-%u.reads.fas",  // read window filename
                         tmp.in->header->target_name[i], tmp.beg + 1, tmp.end + 1);
+                // TODO clean ref_name of special caracters - that would be an alternative to processing everything with regex down the line
+                // BUG the solution currently used by ShoRAH can still fail when path '/' (or on windows '\\' and ':') characters are present in the sam->header->target_name
+
                 tmp.outFile.open(filename, std::ios::out);
                 bam_fetch(tmp.in->x.bam, idx, i, tmp.beg, tmp.end, &tmp,
                           fetch_func1);         // fetch and write reads

--- a/src/cpp/dpm_sampler.cpp
+++ b/src/cpp/dpm_sampler.cpp
@@ -77,7 +77,12 @@ int main(int argc, char** argv)
     std::string instr = filein;
 
     /// rename sampling file and debug file
-    int insize = instr.find('.');
+    // TODO once bioconda moves to gcc 4.9+ (with c++11 regex library), we could convert the whole rename section to regex, to keep coherent accross the whole project
+    int insize = instr.rfind(".reads");  // NOTE : this is robust enough against name generated in b2w.cpp:246
+    if (insize == std::string::npos)
+        insize = instr.length();
+    // TODO clean ref_name of special caracters - that would be an alternative to processing everything with regex down the line. But that will break any legacy data set
+    // BUG the solution currently used by ShoRAH can still fail when path '/' (or on windows '\\' and ':') characters are present in the sam->header->target_name
     std::string statstr = instr.substr(0, insize).append(".dbg");
     std::string outstr = instr.substr(0, insize).append(".smp");
     std::string alphastr = instr.substr(0, insize).append(".alpha");
@@ -1892,7 +1897,7 @@ void write_posterior_files(std::string instr)
     /** All the posterior information is written here
    */
     //  std::cout << "HISTORY = " << HISTORY << std::endl;
-    int insize = instr.rfind('.');
+    int insize = instr.rfind('.'); // NOTE robust against dots in id name
     std::string corstr = instr.substr(0, insize).append("-cor.fas");
     std::string supstr = instr.substr(0, insize).append("-support.fas");
     std::string freqstr = instr.substr(0, insize).append("-freq.csv");


### PR DESCRIPTION
Did a quick edit today to handle issue #32 and weird characters in fasta headers.

Questions :
 - shall I keep this regex-based approach ?
 - (Or shall I try to make a fasta header name-cleaning routine that removes anything weird)
 - I've gone using 'rfind' in c++, because regex are missing in the GCC (4.8) used by bio-conda
 - But I could use boost::regex as a fall-back (see docopt in Haploclique)