### PR TITLE
Search for executables in PATH

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ def move_files():
     for exe in ['b2w', 'diri_sampler', 'fil']:
         shu = shutil.copy('%s/%s' % (exe_dir, exe), 'src/shorah/bin')
         print(shu)
+
+
 class CustomDevelop(develop):
     """Subclassing develop to install files in the correct location."""
     def run(self):

--- a/src/shorah/amplicon.py
+++ b/src/shorah/amplicon.py
@@ -54,13 +54,12 @@ diri_exe = resource_filename(__name__, 'bin/diri_sampler')
 b2w_exe = resource_filename(__name__, 'bin/b2w')
 
 if not os.path.exists(diri_exe) or not os.path.exists(b2w_exe):
-    for path in os.environ["PATH"].split(os.pathsep):
-        diri_exe = os.path.join(path, 'diri_sampler')
-        b2w_exe = os.path.join(path, 'b2w')
-        if os.path.exists(diri_exe) and os.path.exists(b2w_exe):
-            break
-    logging.error('Executables b2w and diri_sampler not found, compile first.')
-    sys.exit('Executables b2w and diri_sampler not found, compile first.')
+    import shutil
+    diri_exe = shutil.which('diri_sampler')
+    b2w_exe = shutil.which('b2w')
+    if not (diri_exe and b2w_exe):
+        logging.error('Executables b2w and diri_sampler not found, compile first.')
+        sys.exit('Executables b2w and diri_sampler not found, compile first.')
 
 win_min_ext = 0.95
 cutoff_depth = 10000

--- a/src/shorah/amplicon.py
+++ b/src/shorah/amplicon.py
@@ -22,11 +22,11 @@
 
 # You should have received a copy of the GNU General Public License
 # along with ShoRAH.  If not, see <http://www.gnu.org/licenses/>.
-'''amplian.py is the program that performs the analysis in amplicon mode.
+"""amplian.py is the program that performs the analysis in amplicon mode.
    It creates a MSA of the reads and performs error correction with a
    single run of diri_sampler. Then, it performs SNV discovery by
    calling the program snv.py.
-   '''
+   """
 from __future__ import division
 from __future__ import print_function
 import os
@@ -53,12 +53,21 @@ else:
 diri_exe = resource_filename(__name__, 'bin/diri_sampler')
 b2w_exe = resource_filename(__name__, 'bin/b2w')
 
+if not os.path.exists(diri_exe) or not os.path.exists(b2w_exe):
+    for path in os.environ["PATH"].split(os.pathsep):
+        diri_exe = os.path.join(path, 'diri_sampler')
+        b2w_exe = os.path.join(path, 'b2w')
+        if os.path.exists(diri_exe) and os.path.exists(b2w_exe):
+            break
+    logging.error('Executables b2w and diri_sampler not found, compile first.')
+    sys.exit('Executables b2w and diri_sampler not found, compile first.')
+
 win_min_ext = 0.95
 cutoff_depth = 10000
 
 
 def run_child(exe_name, arg_string):
-    '''use subrocess to run an external program with arguments'''
+    """use subrocess to run an external program with arguments"""
     import subprocess
 
     if not arg_string.startswith(' '):
@@ -80,8 +89,8 @@ def run_child(exe_name, arg_string):
 
 
 def run_diagnostics(window_file, reads):
-    '''Performs some basic diagnostics on the quality of the MC sampling
-    '''
+    """Performs some basic diagnostics on the quality of the MC sampling
+    """
     import warnings
 
     smp_file = window_file.split('.')[0] + '.smp'
@@ -127,7 +136,7 @@ def run_diagnostics(window_file, reads):
 
 
 def matchremove(matchobj):
-    '''Callback function used in mpileup manipulation'''
+    """Callback function used in mpileup manipulation"""
     match = matchobj.group(0)
     if match.startswith('+') or match.startswith('-'):
         c = int(match[1:])
@@ -138,8 +147,8 @@ def matchremove(matchobj):
 
 
 def shannon_entropy(bases):
-    '''Shannon entropy of a mpileup column: Pseudocount = 1 and
-    returns 0 if length = 1'''
+    """Shannon entropy of a mpileup column: Pseudocount = 1 and
+    returns 0 if length = 1"""
     import math
     if len(bases) == 1:
         return 0.0
@@ -151,7 +160,7 @@ def shannon_entropy(bases):
 
 
 def plot_entropy(pos_ent, pos_coords, ave_ent, win_coords):
-    '''Plot entropies and window to a pdf file with matplotlib'''
+    """Plot entropies and window to a pdf file with matplotlib"""
     try:
         import matplotlib.pyplot as plt
     except ImportError:
@@ -186,8 +195,8 @@ def plot_entropy(pos_ent, pos_coords, ave_ent, win_coords):
     del fig
 
 def highest_entropy(bam_file, fasta_file, ent_sel='relative'):
-    '''Parse reads to have their length distribution and compute the
-    trimmed mean read length'''
+    """Parse reads to have their length distribution and compute the
+    trimmed mean read length"""
 
     import re
     import warnings
@@ -306,10 +315,10 @@ def highest_entropy(bam_file, fasta_file, ent_sel='relative'):
 #def main(in_bam, in_fasta, min_overlap=0.95, max_coverage=50000,
 #         alpha=0.5, s=0.01, region='', diversity=False):
 def main(args):
-    '''
+    """
     Performs the amplicon analysis, running diri_sampler
     and analyzing the result
-    '''
+    """
     in_bam = args.b
     in_fasta = args.f
     region = args.r

--- a/src/shorah/amplicon.py
+++ b/src/shorah/amplicon.py
@@ -53,7 +53,7 @@ else:
 diri_exe = resource_filename(__name__, 'bin/diri_sampler')
 b2w_exe = resource_filename(__name__, 'bin/b2w')
 
-if not os.path.exists(diri_exe) or not os.path.exists(b2w_exe):
+if not (os.path.exists(diri_exe) and os.path.exists(b2w_exe)):
     import shutil
     diri_exe = shutil.which('diri_sampler')
     b2w_exe = shutil.which('b2w')

--- a/src/shorah/shorah_snv.py
+++ b/src/shorah/shorah_snv.py
@@ -47,6 +47,13 @@ import logging
 from pkg_resources import resource_filename
 fil_exe = resource_filename(__name__, 'bin/fil')
 
+if not os.path.exists(fil_exe):
+    for path in os.environ["PATH"].split(os.pathsep):
+        fil_exe = os.path.join(path, 'fil')
+        if os.path.exists(fil_exe):
+            break
+    logging.error('Executable fil not found, compile first.')
+    sys.exit('Executable fil not found, compile first.')
 
 # used to parse variants from support files
 posterior_thresh = 0.9

--- a/src/shorah/shorah_snv.py
+++ b/src/shorah/shorah_snv.py
@@ -37,7 +37,6 @@ from __future__ import division
 import glob
 import gzip
 import os
-import shutil
 import sys
 import warnings
 import shlex
@@ -46,12 +45,10 @@ import logging
 
 from pkg_resources import resource_filename
 fil_exe = resource_filename(__name__, 'bin/fil')
-
 if not os.path.exists(fil_exe):
     import shutil
-    diri_exe = shutil.which('diri_sampler')
-    b2w_exe = shutil.which('b2w')
-    if not (diri_exe and b2w_exe):
+    fil_exe = shutil.which('fil')
+    if not fil_exe:
         logging.error('Executable fil not found, compile first.')
         sys.exit('Executable fil not found, compile first.')
 

--- a/src/shorah/shorah_snv.py
+++ b/src/shorah/shorah_snv.py
@@ -48,12 +48,12 @@ from pkg_resources import resource_filename
 fil_exe = resource_filename(__name__, 'bin/fil')
 
 if not os.path.exists(fil_exe):
-    for path in os.environ["PATH"].split(os.pathsep):
-        fil_exe = os.path.join(path, 'fil')
-        if os.path.exists(fil_exe):
-            break
-    logging.error('Executable fil not found, compile first.')
-    sys.exit('Executable fil not found, compile first.')
+    import shutil
+    diri_exe = shutil.which('diri_sampler')
+    b2w_exe = shutil.which('b2w')
+    if not (diri_exe and b2w_exe):
+        logging.error('Executable fil not found, compile first.')
+        sys.exit('Executable fil not found, compile first.')
 
 # used to parse variants from support files
 posterior_thresh = 0.9

--- a/src/shorah/shotgun.py
+++ b/src/shorah/shotgun.py
@@ -22,10 +22,10 @@
 # You should have received a copy of the GNU General Public License
 # along with ShoRAH.  If not, see <http://www.gnu.org/licenses/>.
 
-'''dec.py draws windows on the bam file, cuts them into separate fasta files,
+"""dec.py draws windows on the bam file, cuts them into separate fasta files,
     calls diri_sampler to correct them, and merges the correction into a
     file of corrected reads
-'''
+"""
 
 from __future__ import division
 from __future__ import print_function
@@ -51,6 +51,16 @@ else:
 
 diri_exe = resource_filename(__name__, 'bin/diri_sampler')
 b2w_exe = resource_filename(__name__, 'bin/b2w')
+
+if not os.path.exists(diri_exe) or not os.path.exists(b2w_exe):
+    for path in os.environ["PATH"].split(os.pathsep):
+        diri_exe = os.path.join(path, 'diri_sampler')
+        b2w_exe = os.path.join(path, 'b2w')
+        if os.path.exists(diri_exe) and os.path.exists(b2w_exe):
+            break
+    logging.error('Executables b2w and diri_sampler not found, compile first.')
+    sys.exit('Executables b2w and diri_sampler not found, compile first.')
+
 #################################################
 # a common user should not edit above this line #
 #################################################
@@ -86,8 +96,8 @@ untouched = [[]]
 
 
 def gzip_file(f_name):
-    '''Gzip a file and return the name of the gzipped, removing the original
-    '''
+    """Gzip a file and return the name of the gzipped, removing the original
+    """
     import gzip
     f_in = open(f_name, 'rb')
     f_out = gzip.open(f_name + '.gz', 'wb')
@@ -105,10 +115,10 @@ def parse_aligned_reads(reads_file):
     out_reads = {}
 
     if not os.path.isfile(reads_file):
-        logging.error('There should be a file here: ' + reads_file)
+        logging.error('There should be a file here: %s', reads_file)
         sys.exit('There should be a file here: ' + reads_file)
     else:
-        logging.info('Using file ' + reads_file + ' of aligned reads')
+        logging.info('Using file %s of aligned reads', reads_file)
 
     handle = open(reads_file)
     logging.debug('Parsing aligned reads')
@@ -194,20 +204,20 @@ def run_dpm(run_setting):
     try:
         retcode = subprocess.call(my_prog + my_arg, shell=True)
         if retcode < 0:
-            logging.error('%s %s' % (my_prog, my_arg))
-            logging.error('Child %s terminated by SIG %d' % (my_prog, -retcode))
+            logging.error('%s %s', my_prog, my_arg)
+            logging.error('Child %s terminated by SIG %d', my_prog, -retcode)
         else:
-            logging.debug('run %s finished' % my_arg)
-            logging.debug('Child %s returned %i' % (my_prog, retcode))
+            logging.debug('run %s finished', my_arg)
+            logging.debug('Child %s returned %i', my_prog, retcode)
     except OSError as ee:
-        logging.error('Execution of %s failed: %s' % (my_prog, ee))
+        logging.error('Execution of %s failed: %s', my_prog, ee)
 
     return
 
 
 def correct_reads(chr_c, wstart, wend):
-    ''' Parses corrected reads (in fasta format) and correct the reads
-    '''
+    """ Parses corrected reads (in fasta format) and correct the reads
+    """
     # out_reads[match_rec.id][0] = qstart
     # out_reads[match_rec.id][1] = qstop
     # out_reads[match_rec.id][2] = mstart
@@ -246,7 +256,7 @@ def correct_reads(chr_c, wstart, wend):
         handle.close()
         return
     except IOError:
-        logging.warning('No reads in window %s?' % wstart)
+        logging.warning('No reads in window %s?', wstart)
         return
 
 
@@ -277,8 +287,7 @@ def get_prop(filename):
 
 
 def base_break(baselist):
-    """break the tie if different corrections are found
-    """
+    """Break the tie if different corrections are found."""
     import random
 
     for c1 in count:
@@ -302,8 +311,7 @@ def base_break(baselist):
 
 
 def win_to_run(alpha_w, seed):
-    '''returns windows to run on diri_sampler
-    '''
+    """Return windows to run on diri_sampler."""
 
     rn_list = []
     try:
@@ -316,7 +324,7 @@ def win_to_run(alpha_w, seed):
         j = min(300000, int(cov) * 15)
         rn_list.append((winFile, j, alpha_w, seed))
 
-    del(end)
+    del end
     del(beg, chr1)
     return rn_list
 
@@ -368,10 +376,10 @@ def merge_corrected_reads(aligned_read):
 #def main(in_bam, in_fasta, win_length=201, win_shifts=3, region='',
 #         max_coverage=10000, alpha=0.1, keep_files=True, seed=None):
 def main(args):
-    '''
+    """
     Performs the error correction analysis, running diri_sampler
     and analyzing the result
-    '''
+    """
     from multiprocessing import Pool, cpu_count
     import glob
     import shutil
@@ -451,6 +459,7 @@ def main(args):
     for i in runlist:
         winFile, j, a, s = i
         del a  # in future alpha might be different on each window
+        del s
         parts = winFile.split('.')[0].split('-')
         chrom = '-'.join(parts[1:-2])
         beg = int(parts[-2])
@@ -459,11 +468,11 @@ def main(args):
         # correct reads populates correction and quality, globally defined
         correct_reads(chrom, beg, end)
         stem = 'w-%s-%s-%s' % (chrom, beg, end)
-        logging.info('this is window %s' % stem)
+        logging.info('this is window %s', stem)
         dbg_file = stem + '.dbg'
         # if os.path.exists(dbg_file):
         proposed[beg] = (get_prop(dbg_file), j)
-        logging.info('there were %s proposed' % str(proposed[beg][0]))
+        logging.info('there were %s proposed', str(proposed[beg][0]))
 
     # (re)move intermediate files
     if not keep_all_files:

--- a/src/shorah/shotgun.py
+++ b/src/shorah/shotgun.py
@@ -53,13 +53,12 @@ diri_exe = resource_filename(__name__, 'bin/diri_sampler')
 b2w_exe = resource_filename(__name__, 'bin/b2w')
 
 if not os.path.exists(diri_exe) or not os.path.exists(b2w_exe):
-    for path in os.environ["PATH"].split(os.pathsep):
-        diri_exe = os.path.join(path, 'diri_sampler')
-        b2w_exe = os.path.join(path, 'b2w')
-        if os.path.exists(diri_exe) and os.path.exists(b2w_exe):
-            break
-    logging.error('Executables b2w and diri_sampler not found, compile first.')
-    sys.exit('Executables b2w and diri_sampler not found, compile first.')
+    import shutil
+    diri_exe = shutil.which('diri_sampler')
+    b2w_exe = shutil.which('b2w')
+    if not (diri_exe and b2w_exe):
+        logging.error('Executables b2w and diri_sampler not found, compile first.')
+        sys.exit('Executables b2w and diri_sampler not found, compile first.')
 
 #################################################
 # a common user should not edit above this line #

--- a/src/shorah/shotgun.py
+++ b/src/shorah/shotgun.py
@@ -52,7 +52,7 @@ else:
 diri_exe = resource_filename(__name__, 'bin/diri_sampler')
 b2w_exe = resource_filename(__name__, 'bin/b2w')
 
-if not os.path.exists(diri_exe) or not os.path.exists(b2w_exe):
+if not (os.path.exists(diri_exe) and os.path.exists(b2w_exe)):
     import shutil
     diri_exe = shutil.which('diri_sampler')
     b2w_exe = shutil.which('b2w')


### PR DESCRIPTION
Added a mechanism in python code that searches for executables in the
whole PATH locations, if they are not in src/shorah/bin. This works for
installations obtained with pip install, and should also work with
autotools.

Minor modifications include proper logging arguments and use of double
quotes in docstrings (not yet PEP257 compliant).