### PR TITLE
Fixing behaviour with indels

### DIFF
--- a/src/cpp/fil.cpp
+++ b/src/cpp/fil.cpp
@@ -296,4 +296,5 @@ int main(int argc, char* argv[])
     bam_hdr_destroy(header);
     hts_idx_destroy(idx);
     hts_close(inFile);
+    exit(EXIT_SUCCESS);
 }

--- a/src/shorah/amplicon.py
+++ b/src/shorah/amplicon.py
@@ -329,6 +329,7 @@ def main(args):
     sigma = args.sigma
     diversity = args.diversity
     min_overlap = args.min_overlap
+    ignore_indels = args.ignore_indels;
 
     logging.info(' '.join(sys.argv))
     # info on reference and region if given, or discover high entropy one
@@ -351,10 +352,11 @@ def main(args):
     logging.info('analysing region from %d to %d', reg_start, reg_stop)
 
     # output the reads, aligned to the amplicon
+    d = ' -d' if ignore_indels else ''
 
-    b2w_args = ' -i 0 -w %d -m %d -x %d %s %s %s' % \
+    b2w_args = ' -i 0 -w %d -m %d -x %d%s %s %s %s' % \
         (ref_length, int(min_overlap * ref_length),
-         max_coverage, in_bam, in_fasta, region)
+         max_coverage, d, in_bam, in_fasta, region)
     ret_b2w = run_child(shlex.quote(b2w_exe), b2w_args)
     logging.debug('b2w returned %d', ret_b2w)
 

--- a/src/shorah/cli.py
+++ b/src/shorah/cli.py
@@ -105,6 +105,9 @@ def main():
     parser.add_argument("-S", "--sigma", metavar='FLOAT', default=0.01, type=float,
                         dest="sigma", help="sigma value to use when calling SNVs")
 
+    parser.add_argument("-I", "--ignore_indels", action="store_true", default=False,
+                        dest="ignore_indels", help="ignore SNVs adjacent to insertions/deletions\n(legacy behaviour of 'fil', ignore this option if you don't understand)")
+
     subparsers = parser.add_subparsers(help='available sub-commands')
 
     # create the parser for command "shotgun"

--- a/src/shorah/shorah_snv.py
+++ b/src/shorah/shorah_snv.py
@@ -313,13 +313,13 @@ def printRaw(snpD2, incr):
     out1.close()
 
 
-def sb_filter(in_bam, sigma, amplimode="", max_coverage=100000):
+def sb_filter(in_bam, sigma, amplimode="", drop_indels="", max_coverage=100000):
     """run strand bias filter calling the external program 'fil'
     """
     import subprocess
     # dn = sys.path[0]
     my_prog = shlex.quote(fil_exe)  # os.path.join(dn, 'fil')
-    my_arg = ' -b ' + in_bam + ' -v ' + str(sigma) + amplimode + ' -x ' \
+    my_arg = ' -b ' + in_bam + ' -v ' + str(sigma) + amplimode + drop_indels + ' -x ' \
              + str(max_coverage)
     logging.debug('running %s%s', my_prog, my_arg)
     retcode = subprocess.call(my_prog + my_arg, shell=True)
@@ -348,7 +348,7 @@ def BH(p_vals, n):
     return q_vals_l
 
 
-def main(reference, bam_file, sigma=0.01, increment=1, max_coverage=100000):
+def main(reference, bam_file, sigma=0.01, increment=1, max_coverage=100000, ignore_indels=False):
     '''main code
     '''
     from Bio import SeqIO
@@ -372,12 +372,11 @@ def main(reference, bam_file, sigma=0.01, increment=1, max_coverage=100000):
         logging.debug('snv/SNV.txt found, moving to ./')
         shutil.move('snv/SNV.txt', './')
 
+    d = ' -d' if ignore_indels else ''
+    a = ' -a' if increment == 1 else ''
     # run strand bias filter, output in SNVs_%sigma.txt
-    if increment == 1:
-        retcode_m = sb_filter(bam_file, sigma, amplimode=" -a",
-                              max_coverage=max_coverage)
-    else:
-        retcode_m = sb_filter(bam_file, sigma, max_coverage=max_coverage)
+    retcode_m = sb_filter(bam_file, sigma, amplimode=a, drop_indels=d,
+                            max_coverage=max_coverage)
     if retcode_m is not 0:
         logging.error('sb_filter exited with error %d', retcode_m)
         sys.exit()

--- a/src/shorah/shotgun.py
+++ b/src/shorah/shotgun.py
@@ -145,12 +145,13 @@ def windows(run_settings):
     """run b2w to make windows from bam
     """
     import subprocess
-    bam, fasta, w, i, m, x, reg = run_settings
+    bam, fasta, w, i, m, x, reg, ignore_indels = run_settings
+    d = ' -d' if ignore_indels else ''
     #dn = sys.path[0]
     my_prog = shlex.quote(b2w_exe)  # os.path.join(dn, 'b2w')
 
-    my_arg = ' -w %i -i %i -m %i -x %i %s %s %s' % \
-        (w, i, m, x, bam, fasta, reg)
+    my_arg = ' -w %i -i %i -m %i -x %i%s %s %s %s' % \
+        (w, i, m, x, d, bam, fasta, reg)
 
     try:
         retcode = subprocess.call(my_prog + my_arg, shell=True)
@@ -396,6 +397,7 @@ def main(args):
     alpha = args.a
     keep_files = args.keep_files
     seed = args.seed
+    ignore_indels = args.ignore_indels;
 
     logging.info(' '.join(sys.argv))
 
@@ -419,7 +421,7 @@ def main(args):
 
     # run b2w
     retcode = windows((in_bam, in_fasta, win_length, incr,
-                       win_min_ext * win_length, max_c, region))
+                       win_min_ext * win_length, max_c, region, ignore_indels))
     if retcode is not 0:
         sys.exit('b2w run not successful')
 


### PR DESCRIPTION
 - fil used to drop SNVs nearby insertions and deletions
 - this old behaviour can be re-instated with an option