### PR TITLE
Allocaholic - the 250 millions malloc killer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ python:
 # HTSLib, GSL and Autotools needed
 before_install:
   - sudo add-apt-repository ppa:ondrej/autotools -y
-  - sudo apt-get update -qq
-  - sudo apt-get install -y --allow-unauthenticated libhts-dev gsl-bin libgsl0-dev autoconf automake pkg-config m4
+  - sudo apt-get install -y --allow-unauthenticated libhts-dev libboost-random-dev gsl-bin libgsl0-dev autoconf automake pkg-config m4
   - source ~/virtualenv/python3.7/bin/activate
 
 compiler:

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,8 +20,7 @@ diri_sampler_SOURCES = \
 	src/cpp/data_structures.hpp \
 	src/cpp/dpm_sampler.hpp \
 	src/cpp/dpm_sampler.cpp
-diri_sampler_CPPFLAGS = $(GSL_CFLAGS)
-diri_sampler_LDADD = $(GSL_LIBS)
+diri_sampler_CPPFLAGS = $(BOOST_CPPFLAGS)
 
 b2w_SOURCES = \
 	src/cpp/b2w.cpp

--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,16 @@ PKG_CHECK_MODULES([HTSLIB], [htslib])
 
 
 
+dnl ======================
+dnl Special find for Boost
+dnl ======================
+dnl Boost still doesn't have a .pc in 2018
+
+AX_BOOST_BASE([1.56],, [AC_MSG_ERROR([Shorah needs Boost >= 1.56 headers, but they were not found in your system])])
+dnl we only use headers (beta distribution is in 1.35), no AX_BOOST_{lib} (boost::random is templates only)
+
+
+
 dnl ===================
 dnl Initialise Automake
 dnl ===================
@@ -162,6 +172,8 @@ AC_MSG_RESULT([
 
 	CPPFLAGS : ................ ${CPPFLAGS}
 	LDFLAGS : ................. ${LDFLAGS}
+
+	Boost_CPPFLAGS : .......... ${BOOST_CPPFLAGS}
 
 	HTSlib_CFLAGS : ........... ${HTSLIB_CFLAGS}
 	HTSlib_LIBS : ............. ${HTSLIB_LIBS}

--- a/m4/m4_ax_boost_base.m4
+++ b/m4/m4_ax_boost_base.m4
@@ -1,0 +1,301 @@
+# ===========================================================================
+#      https://www.gnu.org/software/autoconf-archive/ax_boost_base.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_BASE([MINIMUM-VERSION], [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+#
+# DESCRIPTION
+#
+#   Test for the Boost C++ libraries of a particular version (or newer)
+#
+#   If no path to the installed boost library is given the macro searchs
+#   under /usr, /usr/local, /opt and /opt/local and evaluates the
+#   $BOOST_ROOT environment variable. Further documentation is available at
+#   <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_CPPFLAGS) / AC_SUBST(BOOST_LDFLAGS)
+#
+#   And sets:
+#
+#     HAVE_BOOST
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2009 Peter Adolphs
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 45
+
+# example boost program (need to pass version)
+m4_define([_AX_BOOST_BASE_PROGRAM],
+          [AC_LANG_PROGRAM([[
+#include <boost/version.hpp>
+]],[[
+(void) ((void)sizeof(char[1 - 2*!!((BOOST_VERSION) < ($1))]));
+]])])
+
+AC_DEFUN([AX_BOOST_BASE],
+[
+AC_ARG_WITH([boost],
+  [AS_HELP_STRING([--with-boost@<:@=ARG@:>@],
+    [use Boost library from a standard location (ARG=yes),
+     from the specified location (ARG=<path>),
+     or disable it (ARG=no)
+     @<:@ARG=yes@:>@ ])],
+    [
+     AS_CASE([$withval],
+       [no],[want_boost="no";_AX_BOOST_BASE_boost_path=""],
+       [yes],[want_boost="yes";_AX_BOOST_BASE_boost_path=""],
+       [want_boost="yes";_AX_BOOST_BASE_boost_path="$withval"])
+    ],
+    [want_boost="yes"])
+
+
+AC_ARG_WITH([boost-libdir],
+  [AS_HELP_STRING([--with-boost-libdir=LIB_DIR],
+    [Force given directory for boost libraries.
+     Note that this will override library path detection,
+     so use this parameter only if default library detection fails
+     and you know exactly where your boost libraries are located.])],
+  [
+   AS_IF([test -d "$withval"],
+         [_AX_BOOST_BASE_boost_lib_path="$withval"],
+    [AC_MSG_ERROR([--with-boost-libdir expected directory name])])
+  ],
+  [_AX_BOOST_BASE_boost_lib_path=""])
+
+BOOST_LDFLAGS=""
+BOOST_CPPFLAGS=""
+AS_IF([test "x$want_boost" = "xyes"],
+      [_AX_BOOST_BASE_RUNDETECT([$1],[$2],[$3])])
+AC_SUBST(BOOST_CPPFLAGS)
+AC_SUBST(BOOST_LDFLAGS)
+])
+
+
+# convert a version string in $2 to numeric and affect to polymorphic var $1
+AC_DEFUN([_AX_BOOST_BASE_TONUMERICVERSION],[
+  AS_IF([test "x$2" = "x"],[_AX_BOOST_BASE_TONUMERICVERSION_req="1.20.0"],[_AX_BOOST_BASE_TONUMERICVERSION_req="$2"])
+  _AX_BOOST_BASE_TONUMERICVERSION_req_shorten=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '\([[0-9]]*\.[[0-9]]*\)'`
+  _AX_BOOST_BASE_TONUMERICVERSION_req_major=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '\([[0-9]]*\)'`
+  AS_IF([test "x$_AX_BOOST_BASE_TONUMERICVERSION_req_major" = "x"],
+        [AC_MSG_ERROR([You should at least specify libboost major version])])
+  _AX_BOOST_BASE_TONUMERICVERSION_req_minor=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '[[0-9]]*\.\([[0-9]]*\)'`
+  AS_IF([test "x$_AX_BOOST_BASE_TONUMERICVERSION_req_minor" = "x"],
+        [_AX_BOOST_BASE_TONUMERICVERSION_req_minor="0"])
+  _AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
+  AS_IF([test "X$_AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor" = "X"],
+        [_AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor="0"])
+  _AX_BOOST_BASE_TONUMERICVERSION_RET=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req_major \* 100000 \+  $_AX_BOOST_BASE_TONUMERICVERSION_req_minor \* 100 \+ $_AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor`
+  AS_VAR_SET($1,$_AX_BOOST_BASE_TONUMERICVERSION_RET)
+])
+
+dnl Run the detection of boost should be run only if $want_boost
+AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
+    _AX_BOOST_BASE_TONUMERICVERSION(WANT_BOOST_VERSION,[$1])
+    succeeded=no
+
+
+    AC_REQUIRE([AC_CANONICAL_HOST])
+    dnl On 64-bit systems check for system libraries in both lib64 and lib.
+    dnl The former is specified by FHS, but e.g. Debian does not adhere to
+    dnl this (as it rises problems for generic multi-arch support).
+    dnl The last entry in the list is chosen by default when no libraries
+    dnl are found, e.g. when only header-only libraries are installed!
+    AS_CASE([${host_cpu}],
+      [x86_64],[libsubdirs="lib64 libx32 lib lib64"],
+      [ppc64|powerpc64|s390x|sparc64|aarch64|ppc64le|powerpc64le|riscv64],[libsubdirs="lib64 lib lib64"],
+      [libsubdirs="lib"]
+    )
+
+    dnl allow for real multi-arch paths e.g. /usr/lib/x86_64-linux-gnu. Give
+    dnl them priority over the other paths since, if libs are found there, they
+    dnl are almost assuredly the ones desired.
+    AS_CASE([${host_cpu}],
+      [i?86],[multiarch_libsubdir="lib/i386-${host_os}"],
+      [multiarch_libsubdir="lib/${host_cpu}-${host_os}"]
+    )
+
+    dnl first we check the system location for boost libraries
+    dnl this location ist chosen if boost libraries are installed with the --layout=system option
+    dnl or if you install boost with RPM
+    AS_IF([test "x$_AX_BOOST_BASE_boost_path" != "x"],[
+        AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION) includes in "$_AX_BOOST_BASE_boost_path/include"])
+         AS_IF([test -d "$_AX_BOOST_BASE_boost_path/include" && test -r "$_AX_BOOST_BASE_boost_path/include"],[
+           AC_MSG_RESULT([yes])
+           BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path/include"
+           for _AX_BOOST_BASE_boost_path_tmp in $multiarch_libsubdir $libsubdirs; do
+                AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION) lib path in "$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp"])
+                AS_IF([test -d "$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp" && test -r "$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp" ],[
+                        AC_MSG_RESULT([yes])
+                        BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp";
+                        break;
+                ],
+      [AC_MSG_RESULT([no])])
+           done],[
+      AC_MSG_RESULT([no])])
+    ],[
+        if test X"$cross_compiling" = Xyes; then
+            search_libsubdirs=$multiarch_libsubdir
+        else
+            search_libsubdirs="$multiarch_libsubdir $libsubdirs"
+        fi
+        for _AX_BOOST_BASE_boost_path_tmp in /usr /usr/local /opt /opt/local ; do
+            if test -d "$_AX_BOOST_BASE_boost_path_tmp/include/boost" && test -r "$_AX_BOOST_BASE_boost_path_tmp/include/boost" ; then
+                for libsubdir in $search_libsubdirs ; do
+                    if ls "$_AX_BOOST_BASE_boost_path_tmp/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                done
+                BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_path_tmp/$libsubdir"
+                BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path_tmp/include"
+                break;
+            fi
+        done
+    ])
+
+    dnl overwrite ld flags if we have required special directory with
+    dnl --with-boost-libdir parameter
+    AS_IF([test "x$_AX_BOOST_BASE_boost_lib_path" != "x"],
+          [BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_lib_path"])
+
+    AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION)])
+    CPPFLAGS_SAVED="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+    export CPPFLAGS
+
+    LDFLAGS_SAVED="$LDFLAGS"
+    LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+    export LDFLAGS
+
+    AC_REQUIRE([AC_PROG_CXX])
+    AC_LANG_PUSH(C++)
+        AC_COMPILE_IFELSE([_AX_BOOST_BASE_PROGRAM($WANT_BOOST_VERSION)],[
+        AC_MSG_RESULT(yes)
+    succeeded=yes
+    found_system=yes
+        ],[
+        ])
+    AC_LANG_POP([C++])
+
+
+
+    dnl if we found no boost with system layout we search for boost libraries
+    dnl built and installed without the --layout=system option or for a staged(not installed) version
+    if test "x$succeeded" != "xyes" ; then
+        CPPFLAGS="$CPPFLAGS_SAVED"
+        LDFLAGS="$LDFLAGS_SAVED"
+        BOOST_CPPFLAGS=
+        if test -z "$_AX_BOOST_BASE_boost_lib_path" ; then
+            BOOST_LDFLAGS=
+        fi
+        _version=0
+        if test -n "$_AX_BOOST_BASE_boost_path" ; then
+            if test -d "$_AX_BOOST_BASE_boost_path" && test -r "$_AX_BOOST_BASE_boost_path"; then
+                for i in `ls -d $_AX_BOOST_BASE_boost_path/include/boost-* 2>/dev/null`; do
+                    _version_tmp=`echo $i | sed "s#$_AX_BOOST_BASE_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
+                    V_CHECK=`expr $_version_tmp \> $_version`
+                    if test "x$V_CHECK" = "x1" ; then
+                        _version=$_version_tmp
+                    fi
+                    VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
+                    BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path/include/boost-$VERSION_UNDERSCORE"
+                done
+                dnl if nothing found search for layout used in Windows distributions
+                if test -z "$BOOST_CPPFLAGS"; then
+                    if test -d "$_AX_BOOST_BASE_boost_path/boost" && test -r "$_AX_BOOST_BASE_boost_path/boost"; then
+                        BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path"
+                    fi
+                fi
+                dnl if we found something and BOOST_LDFLAGS was unset before
+                dnl (because "$_AX_BOOST_BASE_boost_lib_path" = ""), set it here.
+                if test -n "$BOOST_CPPFLAGS" && test -z "$BOOST_LDFLAGS"; then
+                    for libsubdir in $libsubdirs ; do
+                        if ls "$_AX_BOOST_BASE_boost_path/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                    done
+                    BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_path/$libsubdir"
+                fi
+            fi
+        else
+            if test "x$cross_compiling" != "xyes" ; then
+                for _AX_BOOST_BASE_boost_path in /usr /usr/local /opt /opt/local ; do
+                    if test -d "$_AX_BOOST_BASE_boost_path" && test -r "$_AX_BOOST_BASE_boost_path" ; then
+                        for i in `ls -d $_AX_BOOST_BASE_boost_path/include/boost-* 2>/dev/null`; do
+                            _version_tmp=`echo $i | sed "s#$_AX_BOOST_BASE_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
+                            V_CHECK=`expr $_version_tmp \> $_version`
+                            if test "x$V_CHECK" = "x1" ; then
+                                _version=$_version_tmp
+                                best_path=$_AX_BOOST_BASE_boost_path
+                            fi
+                        done
+                    fi
+                done
+
+                VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
+                BOOST_CPPFLAGS="-I$best_path/include/boost-$VERSION_UNDERSCORE"
+                if test -z "$_AX_BOOST_BASE_boost_lib_path" ; then
+                    for libsubdir in $libsubdirs ; do
+                        if ls "$best_path/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                    done
+                    BOOST_LDFLAGS="-L$best_path/$libsubdir"
+                fi
+            fi
+
+            if test -n "$BOOST_ROOT" ; then
+                for libsubdir in $libsubdirs ; do
+                    if ls "$BOOST_ROOT/stage/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                done
+                if test -d "$BOOST_ROOT" && test -r "$BOOST_ROOT" && test -d "$BOOST_ROOT/stage/$libsubdir" && test -r "$BOOST_ROOT/stage/$libsubdir"; then
+                    version_dir=`expr //$BOOST_ROOT : '.*/\(.*\)'`
+                    stage_version=`echo $version_dir | sed 's/boost_//' | sed 's/_/./g'`
+                        stage_version_shorten=`expr $stage_version : '\([[0-9]]*\.[[0-9]]*\)'`
+                    V_CHECK=`expr $stage_version_shorten \>\= $_version`
+                    if test "x$V_CHECK" = "x1" && test -z "$_AX_BOOST_BASE_boost_lib_path" ; then
+                        AC_MSG_NOTICE(We will use a staged boost library from $BOOST_ROOT)
+                        BOOST_CPPFLAGS="-I$BOOST_ROOT"
+                        BOOST_LDFLAGS="-L$BOOST_ROOT/stage/$libsubdir"
+                    fi
+                fi
+            fi
+        fi
+
+        CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+        export CPPFLAGS
+        LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+        export LDFLAGS
+
+        AC_LANG_PUSH(C++)
+            AC_COMPILE_IFELSE([_AX_BOOST_BASE_PROGRAM($WANT_BOOST_VERSION)],[
+            AC_MSG_RESULT(yes)
+        succeeded=yes
+        found_system=yes
+            ],[
+            ])
+        AC_LANG_POP([C++])
+    fi
+
+    if test "x$succeeded" != "xyes" ; then
+        if test "x$_version" = "x0" ; then
+            AC_MSG_NOTICE([[We could not detect the boost libraries (version $1 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.]])
+        else
+            AC_MSG_NOTICE([Your boost libraries seems to old (version $_version).])
+        fi
+        # execute ACTION-IF-NOT-FOUND (if present):
+        ifelse([$3], , :, [$3])
+    else
+        AC_DEFINE(HAVE_BOOST,,[define if the Boost library is available])
+        # execute ACTION-IF-FOUND (if present):
+        ifelse([$2], , :, [$2])
+    fi
+
+    CPPFLAGS="$CPPFLAGS_SAVED"
+    LDFLAGS="$LDFLAGS_SAVED"
+
+])

--- a/src/cpp/b2w.cpp
+++ b/src/cpp/b2w.cpp
@@ -107,10 +107,12 @@ int main(int argc, char* argv[])
     };
 
     char help_string[] =
-        "\nUsage: b2w [options] <in.bam> <in.fasta> region\n\nOptions:\n\t-w: window length "
+        "\nUsage: b2w [options] <in.bam> <in.fasta> [region]\n\nOptions:\n\t-w: window length "
         "(INT)\n\t-i: increment (INT)\n\t-m: minimum overlap (INT)\n\t-x: max reads starting at a "
         "position (INT)\n\t-c: coverage threshold. Omit windows with low coverage (INT)\n\t"
         "-d: drop SNVs that are adjacent to insertions/deletions (alternate behaviour)\n\t-h: show this help\n\n";
+
+    const char* bamname = nullptr, * fastaname = nullptr, * regionname = nullptr;
 
     while ((c = getopt(argc, argv, "w:i:m:x:c:dh")) != EOF) {
         switch (c) {
@@ -141,30 +143,34 @@ int main(int argc, char* argv[])
                 exit(EXIT_FAILURE);
         }
     }
+    // remaining parameters: <in.bam> <in.fasta> region
     if ((argc - optind) < 2 or (argc - optind) > 3) {
         std::fprintf(stderr, "%d parameters left, %s", argc - optind, help_string);
         return 1;
     }
+    bamname=argv[optind];
+    fastaname=argv[optind + 1];
+    regionname=(argc == optind + 3) ? argv[optind + 2] : nullptr;
 
-    if (NULL == (inFile = hts_open(argv[optind], "r"))) {  // open bam file
-        std::fprintf(stderr, "Failed to open BAM file %s\n", argv[optind]);
+    if (NULL == (inFile = hts_open(bamname, "r"))) {  // open bam file
+        std::fprintf(stderr, "Failed to open BAM file %s\n", bamname);
         return 2;
     }
 
-    if (fai_build(argv[optind + 1])) {  // generate reference index
-        std::fprintf(stderr, "Failed to index FASTA file %s\n", argv[optind + 1]);
+    if (fai_build(fastaname)) {  // generate reference index
+        std::fprintf(stderr, "Failed to index FASTA file %s\n", fastaname);
         return 3;
     }
-    if (NULL == (fai = fai_load(argv[optind + 1]))) {
-        std::fprintf(stderr, "Failed to load FASTA file %s\n", argv[optind + 1]);
+    if (NULL == (fai = fai_load(fastaname))) {
+        std::fprintf(stderr, "Failed to load FASTA file %s\n", fastaname);
         return 2;
     }
 
     const int idx_min_shift = 0; // NOTE BAI sufficient for up to 2^29-1. If we move from virus to organism with longer chromosomes (plants ?), we should switch to HTS_FMT_CSI [default idx_min_shift = 14]
-    int iBuild = bam_index_build(argv[optind], idx_min_shift);  // generate bam index
+    int iBuild = bam_index_build(bamname, idx_min_shift);  // generate bam index
     UNUSED(iBuild);
     hts_idx_t* idx;
-    if (NULL == (idx = hts_idx_load(argv[optind], idx_min_shift ? HTS_FMT_CSI : HTS_FMT_BAI))) {  // load bam index
+    if (NULL == (idx = hts_idx_load(bamname, idx_min_shift ? HTS_FMT_CSI : HTS_FMT_BAI))) {  // load bam index
         std::fprintf(stderr, "BAM indexing file is not available.\n");
         return 3;
     }
@@ -199,7 +205,7 @@ int main(int argc, char* argv[])
         {
             std::vector<int> rLen(lnth, 0);  // list for read start coverage
             std::vector<char> rd;
-            rd.reserve(301);  // reasonnable initial buffer size to avoid frequent re-allocation. Most HTS tend to use protocols that yield between 100 and 250 bp
+            rd.reserve(301);  // reasonable initial buffer size to avoid frequent re-allocation. Most HTS tend to use protocols that yield between 100 and 250 bp
             // based on samtools/bam.c:bam_fetch
             // TODO These BAM iterator functions work only on BAM files.  To work with either BAM or CRAM files use the sam_index_load() & sam_itr_*() functions.
             bam1_t *b = bam_init1();
@@ -318,7 +324,7 @@ int main(int argc, char* argv[])
         delete [] rd;
     };
 
-    if (argc == optind + 2) {          // region not specified
+    if (nullptr == regionname) {          // region not specified
         for (int i = 0; i < n; i++)
             process_ROI(i,  // take each chromosome in turn
                     0,      // region of interest's start coordinate, 0-based
@@ -326,7 +332,7 @@ int main(int argc, char* argv[])
     } else {  // parse specific region
         // based on samtools/bam_aux.c:bam_parse_region
         int ref_id = -1, roi_b = 0, roi_e = std::numeric_limits<decltype(roi_e)>::max();
-        const char* roi_str = argv[optind + 2];
+        const char* roi_str = regionname;
         {
             const char* name_lim = hts_parse_reg(roi_str, &roi_b, &roi_e);
             if (name_lim) { // valid name ?

--- a/src/cpp/b2w.cpp
+++ b/src/cpp/b2w.cpp
@@ -198,6 +198,8 @@ int main(int argc, char* argv[])
 
         {
             std::vector<int> rLen(lnth, 0);  // list for read start coverage
+            std::vector<char> rd;
+            rd.reserve(301);  // reasonnable initial buffer size to avoid frequent re-allocation. Most HTS tend to use protocols that yield between 100 and 250 bp
             // based on samtools/bam.c:bam_fetch
             // TODO These BAM iterator functions work only on BAM files.  To work with either BAM or CRAM files use the sam_index_load() & sam_itr_*() functions.
             bam1_t *b = bam_init1();
@@ -212,8 +214,8 @@ int main(int argc, char* argv[])
                 int* cv = rLen.data() + Rstart;
                 *cv += 1;
                 if ((*cv < param.max) && (readLen >= param.min_overlap)) {
-                    std::vector<char> rd(readLen + 1, 'N');
-                    rd.back() = '\0';
+                    rd.assign(readLen,'N');
+                    rd.push_back('\0');
                     // based on samtools/bam_plbuf.c
                     {
                         int n_plp, tid, pos;

--- a/src/cpp/dpm_sampler.cpp
+++ b/src/cpp/dpm_sampler.cpp
@@ -70,8 +70,8 @@ int main(int argc, char** argv)
     FILE* iterfile;
     float alpha2;
 
-    double_threshold_min = gsl_sf_log(DBL_MIN);
-    double_threshold_max = gsl_sf_log(DBL_MAX);
+    double_threshold_min = std::log(DBL_MIN);
+    double_threshold_max = std::log(DBL_MAX);
     parsecommandline(argc, argv);
 
     std::string instr = filein;
@@ -955,7 +955,7 @@ double sample_ref()
             if (b1 != 1.0) {
 
                 for (i = 0; i < B; i++) {
-                    log_pbase[i] = cbase[i] * gsl_sf_log(b1) + (K1 - cbase[i]) * gsl_sf_log(b2);
+                    log_pbase[i] = cbase[i] * std::log(b1) + (K1 - cbase[i]) * std::log(b2);
                 }
                 max_log_pbase = log_pbase[0];
                 base_id = 0;
@@ -975,7 +975,7 @@ double sample_ref()
                         if (log_pbase[i] < double_threshold_min) {
                             pbase[i] = 0.0;
                         } else {
-                            pbase[i] = gsl_sf_exp(log_pbase[i]);
+                            pbase[i] = std::exp(log_pbase[i]);
                         }
                     }
                 }
@@ -1057,10 +1057,10 @@ void sample_hap(cnode* cn)
             for (i = 0; i < B; i++) {
                 if (tot_reads > 0) {  // base is not N: sample from reads in the cluster
                     log_pbase[i] =
-                        cbase[i] * gsl_sf_log(b1) + (tot_reads - cbase[i]) * gsl_sf_log(b2);
+                        cbase[i] * std::log(b1) + (tot_reads - cbase[i]) * std::log(b2);
                 } else  // base is N: sample from all reads
-                    log_pbase[i] = ftable[j][i] * gsl_sf_log(b1) +
-                                   (ftable_sum[j] - ftable[j][i]) * gsl_sf_log(b2);
+                    log_pbase[i] = ftable[j][i] * std::log(b1) +
+                                   (ftable_sum[j] - ftable[j][i]) * std::log(b2);
             }
             max_log_pbase = log_pbase[0];
             base_id = 0;
@@ -1079,7 +1079,7 @@ void sample_hap(cnode* cn)
                         pbase[i] = 0.0;
                     } else {
                         // std::cout<<"log_pbase["<<i<<"] = "<<log_pbase[i]<<std::endl;
-                        pbase[i] = gsl_sf_exp(log_pbase[i]);
+                        pbase[i] = std::exp(log_pbase[i]);
                     }
                 }
             }
@@ -1427,16 +1427,16 @@ ssret* sample_class(unsigned int i, unsigned int step)
             nodist = cn->rd1[i];
 
             if (b1 != 1.0) {  // theta < 1.0
-                log_P[st] = gsl_sf_log((double)tw);
-                log_P[st] += nodist * gsl_sf_log(b1);
-                log_P[st] += dist * gsl_sf_log(b2);
+                log_P[st] = std::log((double)tw);
+                log_P[st] += nodist * std::log(b1);
+                log_P[st] += dist * std::log(b2);
                 P[st] = 1.0;  // all probabilities, which should change afterwards, set to 1
             } else {          // theta == 1.0, not needed
                 if (dist != 0) {
                     log_P[st] = double_threshold_min - 1.0;
                     P[st] = 0.0;
                 } else {
-                    log_P[st] = gsl_sf_log((double)tw);
+                    log_P[st] = std::log((double)tw);
                     P[st] = 1.0;  // same as above, P != 0 later
                 }
             }
@@ -1457,19 +1457,19 @@ ssret* sample_class(unsigned int i, unsigned int step)
     nodist = p.second;
 
     b1 = (theta * gam) + (1. - gam) * (1. - theta) / ((double)B - 1.);
-    b2 = (theta + gam + B * (1. - gam * theta) - 2.) / (gsl_sf_pow_int((double)B - 1., 2));
+    b2 = (theta + gam + B * (1. - gam * theta) - 2.) / (std::pow((double)B - 1., 2));
 
     if ((theta == 1.0) && (gam == 1.0)) {
         if (dist == 0) {
-            log_P[st] = gsl_sf_log(alpha);
+            log_P[st] = std::log(alpha);
             P[st] = 1.0;
         } else {
             log_P[st] = double_threshold_min - 1.0;
             P[st] = 0.0;
         }
     } else {
-        log_P[st] = gsl_sf_log(alpha) + gsl_sf_log((double)(readtable2[i]->weight)) +
-                    nodist * gsl_sf_log(b1) + dist * gsl_sf_log(b2);
+        log_P[st] = std::log(alpha) + std::log((double)(readtable2[i]->weight)) +
+                    nodist * std::log(b1) + dist * std::log(b2);
         P[st] = 1.0;
     }
     cl_ptr[st] = NULL;
@@ -1496,7 +1496,7 @@ ssret* sample_class(unsigned int i, unsigned int step)
             else if (log_P[ll] > double_threshold_max)
                 P[ll] = DBL_MAX;
             else {
-                P[ll] = gsl_sf_exp(log_P[ll]);
+                P[ll] = std::exp(log_P[ll]);
             }
         }  // else P[i] = 0, from above
     }
@@ -1805,6 +1805,8 @@ void cleanup()
     free(c_ptr);
     free(pbase);
     free(cbase);
+    free(res_dist);
+    free(res);
     free(log_pbase);
     free(h);
 

--- a/src/cpp/dpm_sampler.cpp
+++ b/src/cpp/dpm_sampler.cpp
@@ -67,6 +67,18 @@ template<typename UNS, typename CDF_type> inline UNS one_shot_discrete_cdf(CDF_t
     return std::upper_bound(cdf.begin(), cdf.begin() + n, wdist(rg)) - cdf.begin(); // usually a binary search
 }
 
+template<typename UNS> inline UNS one_shot_discrete_stupid(const unsigned n, const double* wa) {
+    std::uniform_real_distribution<double> wdist(0.0, std::accumulate(wa, wa+n, 0.));
+    double random = wdist(rg);
+    UNS i;
+    for(i = 0; i < n; i++) {
+        random -= wa[i];
+        if (random < 0.)
+            break;
+    }
+    return i;
+}
+
 // for classes, as their number varies.
 static std::vector<double> cdf_128(128); // static to try reuse memory and reduce mallocs - intial allocation of 1KiB
 static inline long unsigned one_shot_discrete(const unsigned n, const double* wa) {
@@ -77,8 +89,11 @@ static inline long unsigned one_shot_discrete(const unsigned n, const double* wa
 
 // for bases, because they are compile time fixed to 5 (A,T,C,G and '-' deletion) in dpm_sampler.hpp:32
 static inline short unsigned one_shot_discrete_B(const double* wa) {
+/*
     std::array<double, B> cdf_B; // just a (const-) B-sized array, no malloc at all
     return one_shot_discrete_cdf<short unsigned>(cdf_B, B, wa); // in that case, the compiler will fully unroll the partial sums.
+*/
+    return one_shot_discrete_stupid<short unsigned>(B, wa); // compiler efficiently unrolls everything
 }
 
 

--- a/src/cpp/dpm_sampler.hpp
+++ b/src/cpp/dpm_sampler.hpp
@@ -115,9 +115,6 @@ double double_threshold_max;  // will be set to = gsl_sf_log(DBL_MAX);
 // needed for omitting underflow-errors of gsl-functions
 
 // random number generator via gsl
-const gsl_rng_type* T;
-const gsl_rng* rg;          /* gsl, global generator */
-const gsl_rng* urg;         /* gsl, global generator for uniform */
 unsigned long randseed = 0; /* random seed, if no command line parameter
                    -R given, set to current time */
 

--- a/src/cpp/meson.build
+++ b/src/cpp/meson.build
@@ -12,6 +12,7 @@ else
     extra_cpp_args = []
 endif
 
+boost_dep = dependency('boost', version : '>=1.56' ) # we only use headers : boost::random is templates-only
 gsl_dep = dependency('gsl')
 thread_dep = dependency('threads')
 htslib_dep = dependency('htslib', version : '>=1.7')
@@ -23,7 +24,7 @@ dpm_exe = executable(
     'dpm_sampler.cpp']),
   dependencies : [
     thread_dep,
-    gsl_dep],
+    boost_dep],
   cpp_args : extra_cpp_args,
   install : true)
 


### PR DESCRIPTION
A series of fix that speeds-up shorah :

 - by avoiding labyrinthine stacks of function calls for `log`, `exp` and `pow`
 - by avoiding way too many calls to malloc, mostly due to building look-up tables for
   the discrete distributions generator

   (Even more useless in cases where the generator is called once.
   The dual look-up table that enable *O(1)* with two simple steps is over kill).