### PR TITLE
Fix issue #53 -- "local variable 'prop'"

### DIFF
--- a/src/cpp/dpm_sampler.cpp
+++ b/src/cpp/dpm_sampler.cpp
@@ -1321,11 +1321,13 @@ ssret* sample_class(unsigned int i, unsigned int step)
     // if it's in the head
     if (c_ptr[i] == NULL && mxt->size == 1) {
 
-        rn = mxt->next->rlist;
+        if (mxt->next != NULL) {
+                rn = mxt->next->rlist;
 
-        while (rn != NULL) {
-            c_ptr[rn->ri] = NULL;
-            rn = rn->next;
+                while (rn != NULL) {
+                        c_ptr[rn->ri] = NULL;
+                        rn = rn->next;
+                }
         }
 
         remove_comp(&mxt);

--- a/src/shorah/shotgun.py
+++ b/src/shorah/shotgun.py
@@ -281,7 +281,7 @@ def get_prop(filename):
     else:
         return 'not found'
 
-    prop = 0
+    prop = 'not found'
     for l in h:
         if l.startswith('#made'):
             prop = int(l.split()[1])
@@ -334,6 +334,9 @@ def win_to_run(alpha_w, seed):
 
 
 def merge_corrected_reads(aligned_read):
+    if aligned_read is None:
+        print("empty window found", file=sys.stderr)
+        return (None, [])
 
     ID = aligned_read[0]
     seq = aligned_read[1][4]
@@ -615,7 +618,7 @@ def main(args):
     ph = open('proposed.dat', 'w')
     ph.write('#base\tproposed_per_step\n')
     for kp in sorted(proposed):
-        if proposed[kp] != 'not found':
+        if proposed[kp] != 'not found' and 'not found' not in proposed[kp]:
             ph.write('%s\t%f\n' %
                      (kp, proposed[kp][0] / proposed[kp][1]))
     ph.close()


### PR DESCRIPTION
More extended fix to the crashes that did appear when window didn't contain enough sequences,  leading to no output of dpm_sampler.

 - Fix: missing null check that crashed dpm_sampler
 - Fix: no samples that crashed shotgun.py
 - at line 279: use 'not found' instead of zero, because line 618 checks for that too
 - at line 332: also check for empty windows when merging the corrected.