### PR TITLE
Make travis happy again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: c cpp python
 
 python:
-  - "3.6"
+  - "3.7"
 
 # HTSLib, GSL and Autotools needed
 before_install:
   - sudo add-apt-repository ppa:ondrej/autotools -y
-  - sudo add-apt-repository ppa:debian-med/ppa -y
   - sudo apt-get update -qq
   - sudo apt-get install -y --allow-unauthenticated libhts-dev gsl-bin libgsl0-dev autoconf automake pkg-config m4
-  - source ~/virtualenv/python3.6/bin/activate
+  - source ~/virtualenv/python3.7/bin/activate
 
 compiler:
   - gcc


### PR DESCRIPTION
Travis want modernity. Otherwise Travis is sad.

- newer python 3.7
- apparently *debian-med* doesn't do old xenial package anymore
- BUT the libhts-dev from the latest xenial LTS passes our build, so...